### PR TITLE
Fix typos of "assit" to "assist".

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/fragment.e4xmi
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/fragment.e4xmi
@@ -27,7 +27,7 @@
   <fragments xsi:type="fragment:StringModelFragment" xmi:id="_pVgfIIrOEeW7h_qdP9N9fw" featurename="menuContributions" parentElementId="xpath:/">
     <elements xsi:type="menu:MenuContribution" xmi:id="_BducUIrPEeW7h_qdP9N9fw" elementId="com.github.gradusnikov.eclipse.plugin.assistai.main.menucontribution.1" positionInParent="after=additions" parentId="popup">
       <persistedState key="persistState" value="false"/>
-      <children xsi:type="menu:Menu" xmi:id="_Dtii0IrPEeW7h_qdP9N9fw" elementId="org.eclipse.pde.ui.templates.menu.e4handlers" label="Assit AI" iconURI="platform:/plugin/com.github.gradusnikov.eclipse.plugin.assistai.main/icons/Sample.png" tooltip="" mnemonics=" CTRL + I">
+      <children xsi:type="menu:Menu" xmi:id="_Dtii0IrPEeW7h_qdP9N9fw" elementId="org.eclipse.pde.ui.templates.menu.e4handlers" label="Assist AI" iconURI="platform:/plugin/com.github.gradusnikov.eclipse.plugin.assistai.main/icons/Sample.png" tooltip="" mnemonics=" CTRL + I">
         <children xsi:type="menu:HandledMenuItem" xmi:id="_s6Bw0PDVEe26l_NIXSJcoA" elementId="com.github.gradusnikov.eclipse.plugin.assistai.main.handledmenuitem.0" label="Discuss" tooltip="Discuss with ChatGPT about the opened file" command="_eYD8MPDVEe26l_NIXSJcoA"/>
         <children xsi:type="menu:HandledMenuItem" xmi:id="_Dtii0YrPEeW7h_qdP9N9fw" elementId="com.github.gradusnikov.eclipse.plugin.assistai.main.handledmenuitem.1" label="Refactor" iconURI="" tooltip="Asks ChatGPT to refactor the selected code" command="_UCYfwIrOEeW7h_qdP9N9fw"/>
         <children xsi:type="menu:HandledMenuItem" xmi:id="_weYC8N9eEe2hsMR7OZZDNw" elementId="com.github.gradusnikov.eclipse.plugin.assistai.main.handledmenuitem.2" label="Document" tooltip="Asks ChatGPT to document class or method with JavaDoc" command="_TgvO8N9eEe2hsMR7OZZDNw"/>
@@ -38,7 +38,7 @@
     </elements>
   </fragments>
   <fragments xsi:type="fragment:StringModelFragment" xmi:id="_AQJWAM2tEe2ZG5Twjghs_w" featurename="descriptors" parentElementId="xpath:/">
-    <elements xsi:type="basic:PartDescriptor" xmi:id="_CF9oIM2tEe2ZG5Twjghs_w" elementId="assitai.partdescriptor.chatgptview" label="ChatGPT View" iconURI="platform:/plugin/com.github.gradusnikov.eclipse.plugin.assistai.main/icons/Sample.png" category="Assist AI" closeable="true" contributionURI="bundleclass://com.github.gradusnikov.eclipse.plugin.assistai.main/com.github.gradusnikov.eclipse.assistai.part.ChatGPTViewPart">
+    <elements xsi:type="basic:PartDescriptor" xmi:id="_CF9oIM2tEe2ZG5Twjghs_w" elementId="assistai.partdescriptor.chatgptview" label="ChatGPT View" iconURI="platform:/plugin/com.github.gradusnikov.eclipse.plugin.assistai.main/icons/Sample.png" category="Assist AI" closeable="true" contributionURI="bundleclass://com.github.gradusnikov.eclipse.plugin.assistai.main/com.github.gradusnikov.eclipse.assistai.part.ChatGPTViewPart">
       <tags>View</tags>
       <tags>categoryTag:Assist AI</tags>
     </elements>

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/part/ChatGPTPresenter.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/part/ChatGPTPresenter.java
@@ -84,7 +84,7 @@ public class ChatGPTPresenter
     }
 
 
-    public ChatMessage beginMessageFromAssitant()
+    public ChatMessage beginMessageFromAssistant()
     {   
         ChatMessage message = chatMessageFactory.createAssistantChatMessage("");
         conversation.add(message);

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/part/PartAccessor.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/part/PartAccessor.java
@@ -31,7 +31,7 @@ public class PartAccessor
     public Optional<ChatGPTViewPart> findMessageView() 
     {
         // Find the MessageView by element ID in the application model
-        return modelService.findElements(application, "assitai.partdescriptor.chatgptview", MPart.class)
+        return modelService.findElements(application, "assistai.partdescriptor.chatgptview", MPart.class)
                                            .stream()
                                            .findFirst()
                                            .map( mpart -> mpart.getObject() )

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/subscribers/AppendMessageToViewSubscriber.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/subscribers/AppendMessageToViewSubscriber.java
@@ -39,7 +39,7 @@ public class AppendMessageToViewSubscriber implements Flow.Subscriber<String>
     {
         Objects.requireNonNull( presenter );
         this.subscription = subscription;
-        message = presenter.beginMessageFromAssitant();
+        message = presenter.beginMessageFromAssistant();
         subscription.request(1);
     }
 


### PR DESCRIPTION
Fix some typos, such as the menu

<img width="234" alt="image" src="https://github.com/gradusnikov/eclipse-chatgpt-plugin/assets/2924992/1c080de1-3c96-43fe-92d1-4bd7724f67d2">
