### PR TITLE
FIX : JsonUtils.toPrettyJsonString -> JsonUtils.toJsonString

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/OpenAIResponsesJavaHttpClient.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/OpenAIResponsesJavaHttpClient.java
@@ -171,7 +171,7 @@ public class OpenAIResponsesJavaHttpClient implements LanguageModelClient
         // each time a whole conversation context is sent
         requestBody.put("store", false);
         
-        return JsonUtils.toPrettyJsonString(requestBody);
+        return JsonUtils.toJsonString(requestBody);
     }
     
     /**


### PR DESCRIPTION
Hi,
I couldn’t find a method called toPrettyJsonString in the JsonUtils class.
I thought you might mean toJsonString, so I changed it.
If I misunderstood, please let me know.
Thanks!