### PR TITLE
Dispatch timeout preferences to models

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/models/ModelApiDescriptor.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/models/ModelApiDescriptor.java
@@ -1,5 +1,7 @@
 package com.github.gradusnikov.eclipse.assistai.models;
 
+import java.time.Duration;
+
 /**
  * 
  */
@@ -8,6 +10,8 @@ public record ModelApiDescriptor(
          String apiType,
          String apiUrl,
          String apiKey,
+         Duration connectionTimeout,
+         Duration requestTimeout,
          String modelName,
          int temperature,
          boolean vision,
@@ -20,6 +24,8 @@ public record ModelApiDescriptor(
                     stub.apiType(),
                     stub.apiUrl(),
                     stub.apiKey(),
+                    stub.connectionTimeout(),
+                    stub.requestTimeout(),
                     stub.modelName(),
                     stub.temperature(),
                     stub.vision(),

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/AnthropicStreamJavaHttpClient.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/AnthropicStreamJavaHttpClient.java
@@ -292,12 +292,12 @@ public class AnthropicStreamJavaHttpClient extends AbstractLanguageModelClient
 	        }
 	        
 	        HttpClient client = HttpClient.newBuilder()
-	                .connectTimeout(Duration.ofSeconds(configuration.getConnectionTimoutSeconds()))
+	                .connectTimeout(model.connectionTimeout())
 	                .build();
 	
 	        String requestBody = getRequestBody(prompt, model);
 	        HttpRequest request = HttpRequest.newBuilder().uri(URI.create(model.apiUrl()))
-	                .timeout(Duration.ofSeconds(configuration.getRequestTimoutSeconds()))
+	                .timeout(model.requestTimeout())
 	                .version(HttpClient.Version.HTTP_1_1)
 	                .header("x-api-key", model.apiKey())
 	                .header("anthropic-version", "2023-06-01") // Update to latest API version if needed

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/DeepSeekStreamJavaHttpClient.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/DeepSeekStreamJavaHttpClient.java
@@ -9,7 +9,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -317,12 +316,12 @@ public class DeepSeekStreamJavaHttpClient extends AbstractLanguageModelClient
             }
             
             HttpClient client = HttpClient.newBuilder()
-                    .connectTimeout(Duration.ofSeconds(configuration.getConnectionTimoutSeconds()))
+                    .connectTimeout(model.connectionTimeout())
                     .build();
 
             String requestBody = getRequestBody(prompt, model);
             HttpRequest request = HttpRequest.newBuilder().uri(URI.create(model.apiUrl()))
-                    .timeout(Duration.ofSeconds(configuration.getRequestTimoutSeconds()))
+                    .timeout(model.requestTimeout())
                     .version(HttpClient.Version.HTTP_1_1)
                     .header("Authorization", "Bearer " + model.apiKey())
                     .header("Content-Type", "application/json")

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/GeminiStreamJavaHttpClient.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/GeminiStreamJavaHttpClient.java
@@ -5,7 +5,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -393,7 +392,7 @@ public class GeminiStreamJavaHttpClient extends AbstractLanguageModelClient
             publisher = new SubmissionPublisher<>(Runnable::run, Flow.defaultBufferSize());
 
             HttpClient client = HttpClient.newBuilder()
-                    .connectTimeout(Duration.ofSeconds(configuration.getConnectionTimoutSeconds()))
+                    .connectTimeout(model.connectionTimeout())
                     .build();
 
             String requestBody = getRequestBody(prompt, model);
@@ -403,7 +402,7 @@ public class GeminiStreamJavaHttpClient extends AbstractLanguageModelClient
             
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(apiUrl))
-                    .timeout(Duration.ofSeconds(configuration.getRequestTimoutSeconds()))
+                    .timeout(model.requestTimeout())
                     .header("Content-Type", "application/json")
                     .header("x-goog-api-key", model.apiKey())
                     .POST(HttpRequest.BodyPublishers.ofString(requestBody))

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/GrokStreamJavaHttpClient.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/GrokStreamJavaHttpClient.java
@@ -10,7 +10,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -268,12 +267,12 @@ public class GrokStreamJavaHttpClient extends AbstractLanguageModelClient
             }
             
             HttpClient client = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(configuration.getConnectionTimoutSeconds()))
+                .connectTimeout(model.connectionTimeout())
                 .build();
             String requestBody = getRequestBody(prompt, model);
             HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(model.apiUrl()))
-                .timeout(Duration.ofSeconds(configuration.getRequestTimoutSeconds()))
+                .timeout(model.requestTimeout())
                 .version(HttpClient.Version.HTTP_1_1)
                 .header("Authorization", "Bearer " + model.apiKey())
                 .header("Content-Type", "application/json")

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/LanguageModelClientConfiguration.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/LanguageModelClientConfiguration.java
@@ -1,14 +1,6 @@
 package com.github.gradusnikov.eclipse.assistai.network.clients;
 
-import java.util.Optional;
-
 import org.eclipse.e4.core.di.annotations.Creatable;
-import org.eclipse.jface.preference.IPreferenceStore;
-
-import com.github.gradusnikov.eclipse.assistai.Activator;
-import com.github.gradusnikov.eclipse.assistai.models.ModelApiDescriptor;
-import com.github.gradusnikov.eclipse.assistai.models.ModelApiDescriptorRepository;
-import com.github.gradusnikov.eclipse.assistai.preferences.PreferenceConstants;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -20,18 +12,6 @@ public class LanguageModelClientConfiguration
     @Inject
     public LanguageModelClientConfiguration( )
     {
-    }
-    
-    public int getConnectionTimoutSeconds()
-    {
-        IPreferenceStore prefernceStore = Activator.getDefault().getPreferenceStore();
-        return Integer.parseInt( prefernceStore.getString(PreferenceConstants.ASSISTAI_CONNECTION_TIMEOUT_SECONDS) );
-    }
-    
-    public int getRequestTimoutSeconds()
-    {
-        IPreferenceStore prefernceStore = Activator.getDefault().getPreferenceStore();
-        return Integer.parseInt( prefernceStore.getString(PreferenceConstants.ASSISTAI_REQUEST_TIMEOUT_SECONDS) );
     }
     
 }

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/OpenAIResponsesJavaHttpClient.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/OpenAIResponsesJavaHttpClient.java
@@ -6,7 +6,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -336,14 +335,14 @@ public class OpenAIResponsesJavaHttpClient extends AbstractLanguageModelClient
             }
 
             HttpClient client = HttpClient.newBuilder()
-                    .connectTimeout(Duration.ofSeconds(configuration.getConnectionTimoutSeconds()))
+                    .connectTimeout(model.connectionTimeout())
                     .build();
             
             String requestBody = getRequestBody(prompt, model);
             
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(model.apiUrl()))
-                    .timeout(Duration.ofSeconds(configuration.getRequestTimoutSeconds()))
+                    .timeout(model.requestTimeout())
                     .version(HttpClient.Version.HTTP_1_1)
                     .header("Authorization", "Bearer " + model.apiKey())
                     .header("Accept", "text/event-stream")

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/OpenAIStreamJavaHttpClient.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/OpenAIStreamJavaHttpClient.java
@@ -277,12 +277,12 @@ public class OpenAIStreamJavaHttpClient extends AbstractLanguageModelClient
     	    }
     		
     	    HttpClient client = HttpClient.newBuilder()
-    		                              .connectTimeout( Duration.ofSeconds(configuration.getConnectionTimoutSeconds()) )
+    		                              .connectTimeout( model.connectionTimeout() )
     		                              .build();
     		
     		String requestBody = getRequestBody(prompt, model);
             HttpRequest request = HttpRequest.newBuilder().uri(URI.create(model.apiUrl()))
-                    .timeout( Duration.ofSeconds( configuration.getRequestTimoutSeconds() ) )
+                    .timeout( model.requestTimeout() )
                     .version(HttpClient.Version.HTTP_1_1)
     				.header("Authorization", "Bearer " + model.apiKey())
     				.header("Accept", "text/event-stream")

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/preferences/PreferenceConstants.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/preferences/PreferenceConstants.java
@@ -5,8 +5,6 @@ package com.github.gradusnikov.eclipse.assistai.preferences;
  */
 public class PreferenceConstants
 {
-    public static final String ASSISTAI_CONNECTION_TIMEOUT_SECONDS = "AssistAIConnectionTimeoutSeconds";
-    public static final String ASSISTAI_REQUEST_TIMEOUT_SECONDS = "AssistAIRequestTimeoutSeconds";
     public static final String ASSISTAI_CHAT_MODEL = "AssistaAISelectedModel";
     public static final String ASSISTAI_DEFINED_MODELS = "AssistAIDefinedModels";
     

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/preferences/PreferenceInitializer.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/preferences/PreferenceInitializer.java
@@ -3,7 +3,7 @@ package com.github.gradusnikov.eclipse.assistai.preferences;
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.e4.core.di.annotations.Creatable;
 import org.eclipse.jface.preference.IPreferenceStore;
-
+import java.time.Duration;
 import java.util.UUID;
 
 import com.github.gradusnikov.eclipse.assistai.Activator;
@@ -39,21 +39,21 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer
     {
         init();
         
-        IPreferenceStore store = Activator.getDefault().getPreferenceStore();
-        store.setDefault( PreferenceConstants.ASSISTAI_CONNECTION_TIMEOUT_SECONDS, 10 );
-        store.setDefault( PreferenceConstants.ASSISTAI_REQUEST_TIMEOUT_SECONDS, 30 );
-
-        ModelApiDescriptor gpt4 = new ModelApiDescriptor( "5e8d3a9f-c5e2-4c1d-9f3b-a7e6b4d2c1e0", "openai", "https://api.openai.com/v1/chat/completions", "", "gpt-4o", 7, true, true );
-        ModelApiDescriptor claude = new ModelApiDescriptor( "8d099c40-5a01-483b-878f-bfed8c0d1bbe", "claude", "https://api.anthropic.com/v1/messages", "", "claude-3-7-sonnet-20250219", 7, true, true );
-        ModelApiDescriptor groq = new ModelApiDescriptor( "9c4d7e8f-a1b2-3c4d-5e6f-7a8b9c0d1e2f", "groq", "https://api.groq.com/openai/v1/chat/completions", "", "qwen-qwq-32b", 7, false, true );
-        ModelApiDescriptor deepseek = new ModelApiDescriptor( "4e28814b-d7cd-42f5-bd3e-0df577a3d2c4", "deepseek", "https://api.deepseek.com/chat/completions", "", "deepseek-chat", 7, false, true );
-        ModelApiDescriptor gemini = new ModelApiDescriptor( "15742962-271f-4ffb-80aa-58224631015a", "gemini", "https://generativelanguage.googleapis.com/v1beta", "", "gemini-2.0-flash", 7, true, true );
+        Duration conTimeout = Duration.ofSeconds(10);
+        Duration reqTimeout = Duration.ofSeconds(30);
+        ModelApiDescriptor gpt4 = new ModelApiDescriptor( "5e8d3a9f-c5e2-4c1d-9f3b-a7e6b4d2c1e0", "openai", "https://api.openai.com/v1/chat/completions", "", conTimeout, reqTimeout, "gpt-4o", 7, true, true );
+        ModelApiDescriptor claude = new ModelApiDescriptor( "8d099c40-5a01-483b-878f-bfed8c0d1bbe", "claude", "https://api.anthropic.com/v1/messages", "", conTimeout, reqTimeout, "claude-3-7-sonnet-20250219", 7, true, true );
+        ModelApiDescriptor groq = new ModelApiDescriptor( "9c4d7e8f-a1b2-3c4d-5e6f-7a8b9c0d1e2f", "groq", "https://api.groq.com/openai/v1/chat/completions", "", conTimeout, reqTimeout, "qwen-qwq-32b", 7, false, true );
+        ModelApiDescriptor deepseek = new ModelApiDescriptor( "4e28814b-d7cd-42f5-bd3e-0df577a3d2c4", "deepseek", "https://api.deepseek.com/chat/completions", "", conTimeout, reqTimeout, "deepseek-chat", 7, false, true );
+        ModelApiDescriptor gemini = new ModelApiDescriptor( "15742962-271f-4ffb-80aa-58224631015a", "gemini", "https://generativelanguage.googleapis.com/v1beta", "", conTimeout, reqTimeout, "gemini-2.0-flash", 7, true, true );
         
         modelApiDescriptorRepository.initializeDefaultDescriptors( gpt4, claude, groq, deepseek, gemini );
         modelApiDescriptorRepository.initializeDefaultDescriptorInUse( gpt4 );
         
         var descriptors = mcpServerRepository.listBuiltInServers();
         
+        IPreferenceStore store = Activator.getDefault().getPreferenceStore();
+
         String mcpServersJson = McpServerDescriptorUtilities.toJson( descriptors );
         store.setDefault(PreferenceConstants.ASSISTAI_DEFINED_MCP_SERVERS, mcpServersJson);
 

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/preferences/models/ModelListPreferencePage.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/preferences/models/ModelListPreferencePage.java
@@ -1,5 +1,6 @@
 package com.github.gradusnikov.eclipse.assistai.preferences.models;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -44,6 +45,10 @@ public class ModelListPreferencePage extends PreferencePage implements IWorkbenc
     private Text       apiUrl;
 
     private Text       apiKey;
+
+    private Text       connectionTimeout;
+
+    private Text       requestTimeout;
 
     private Text       modelName;
 
@@ -126,6 +131,8 @@ public class ModelListPreferencePage extends PreferencePage implements IWorkbenc
                 "openai", 
                 apiUrl.getText(), 
                 apiKey.getText(), 
+                textToDuration(connectionTimeout.getText()), 
+                textToDuration(requestTimeout.getText()), 
                 modelName.getText(),
                 withTemperature.getSelection(), 
                 withVision.getSelection(), 
@@ -168,6 +175,8 @@ public class ModelListPreferencePage extends PreferencePage implements IWorkbenc
 
         apiUrl = addTextField( form, "API Url:");
         apiKey = addTextField( form, "API Key:");
+        connectionTimeout = addTextField( form, "Connection Timeout (seconds):");
+        requestTimeout = addTextField( form, "Request Timeout (seconds):");
         modelName = addTextField( form, "Model Name:");
         withVision = addCheckField( form, "With Vision:");
         withFunctionCalls = addCheckField( form, "With Function Calls:");
@@ -254,6 +263,8 @@ public class ModelListPreferencePage extends PreferencePage implements IWorkbenc
         uiSync.asyncExec( () -> {
             apiUrl.setText( modelApiDescriptor.apiUrl() );
             apiKey.setText( modelApiDescriptor.apiKey() );
+            connectionTimeout.setText( durationToText(modelApiDescriptor.connectionTimeout()) );
+            requestTimeout.setText( durationToText(modelApiDescriptor.requestTimeout()) );
             modelName.setText( modelApiDescriptor.modelName() );
             withTemperature.setSelection( modelApiDescriptor.temperature() );
             withVision.setSelection( modelApiDescriptor.vision() );
@@ -267,6 +278,8 @@ public class ModelListPreferencePage extends PreferencePage implements IWorkbenc
         uiSync.asyncExec( () -> {
             apiUrl.setText( "" );
             apiKey.setText( "" );
+            connectionTimeout.setText( "" );
+            requestTimeout.setText( "" );
             modelName.setText( "" );
             withTemperature.setSelection( 0 );
             withVision.setSelection( false );
@@ -296,4 +309,12 @@ public class ModelListPreferencePage extends PreferencePage implements IWorkbenc
         } );
     }
 
+
+    private static Duration textToDuration(String text) {
+      return Duration.ofSeconds(Long.parseLong(text));
+    }
+
+    private static String durationToText(Duration duration) {
+      return Long.toString(duration.getSeconds());
+    }
 }


### PR DESCRIPTION
Since timeout may vary from API to API (local, low latency remote, high latency remote) and from model to model (GPU vs CPU) the timeout preferences are moved from the global preferences to the model descriptors.

It is an attempt to partially fix #86. I focus here on the ability to configure the connection and request timeouts per model. In the initial code, it appears they were set in the global preferences but not exposed, thus fixed to 10s and 30s. This change should expose them with the same default values, but this time allow to change them per model.

I do not touch the completion timeout, which seems to be a different beast and may be addressed in a different PR.

I don't know how to test this code, so I only changed what I was confident to change as per my mastery in Java. In particular, I didn't add any timeout validation, like ensuring that we only enter strictly positive values. I assume that we should add a modify listener on the 2 text fields, but since I can't test it I didn't take the risk to do something wrong or incomplete. Only adapting and reproducing what was already there.

Since I reused the initial values that were not yet exposed, it should work as before, with the extra capacity to change them now.