### PR TITLE
Add PDE MCP Server with target platform management and JUnit Plug-in …

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/META-INF/MANIFEST.MF
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/META-INF/MANIFEST.MF
@@ -42,6 +42,8 @@ Require-Bundle: org.eclipse.e4.ui.services,
  org.eclipse.ltk.core.refactoring,
  org.eclipse.ltk.ui.refactoring,
  org.eclipse.jdt.core.manipulation,
+ org.eclipse.pde.core,
+ org.eclipse.pde.launching,
  jakarta.annotation-api;bundle-version="2.1.1",
  jakarta.inject.jakarta.inject-api;bundle-version="2.0.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/McpServerBuiltins.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/McpServerBuiltins.java
@@ -13,6 +13,7 @@ import com.github.gradusnikov.eclipse.assistai.mcp.servers.DuckDuckSearchMcpServ
 import com.github.gradusnikov.eclipse.assistai.mcp.servers.EclipseCodeEditingMcpServer;
 import com.github.gradusnikov.eclipse.assistai.mcp.servers.EclipseContextMcpServer;
 import com.github.gradusnikov.eclipse.assistai.mcp.servers.EclipseGitMcpServer;
+import com.github.gradusnikov.eclipse.assistai.mcp.servers.PDEMcpServer;
 import com.github.gradusnikov.eclipse.assistai.mcp.servers.EclipseIntegrationsMcpServer;
 import com.github.gradusnikov.eclipse.assistai.mcp.servers.EclipseRunnerMcpServer;
 import com.github.gradusnikov.eclipse.assistai.mcp.servers.MemoryMcpServer;
@@ -35,7 +36,8 @@ class McpServerBuiltins
             EclipseCodeEditingMcpServer.class,
             EclipseRunnerMcpServer.class,
             EclipseContextMcpServer.class,
-            EclipseGitMcpServer.class
+            EclipseGitMcpServer.class,
+            PDEMcpServer.class
     };
     
     public List<McpServerDescriptor> listBuiltInImplementations()

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/PDEMcpServer.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/PDEMcpServer.java
@@ -1,0 +1,68 @@
+package com.github.gradusnikov.eclipse.assistai.mcp.servers;
+
+import java.util.Optional;
+
+import org.eclipse.e4.core.di.annotations.Creatable;
+
+import com.github.gradusnikov.eclipse.assistai.mcp.annotations.McpServer;
+import com.github.gradusnikov.eclipse.assistai.mcp.annotations.Tool;
+import com.github.gradusnikov.eclipse.assistai.mcp.annotations.ToolParam;
+import com.github.gradusnikov.eclipse.assistai.mcp.services.PDEService;
+
+import jakarta.inject.Inject;
+
+@Creatable
+@McpServer(name = "eclipse-pde")
+public class PDEMcpServer
+{
+    @Inject
+    private PDEService pdeService;
+
+    @Tool(name = "getActiveTarget",
+          description = "Gets information about the currently active Eclipse target platform.",
+          type = "object")
+    public String getActiveTarget()
+    {
+        return pdeService.getActiveTarget();
+    }
+
+    @Tool(name = "setActiveTarget",
+          description = "Sets the active Eclipse target platform from a .target file. Loads and activates the target definition.",
+          type = "object")
+    public String setActiveTarget(
+            @ToolParam(name = "targetFilePath", description = "The workspace-relative or absolute path to the .target file (e.g., '/MyProject/myplatform.target')") String targetFilePath)
+    {
+        return pdeService.setActiveTarget(targetFilePath);
+    }
+
+    @Tool(name = "reloadTarget",
+          description = "Reloads the currently active Eclipse target platform. Useful after target contents change on disk.",
+          type = "object")
+    public String reloadTarget()
+    {
+        return pdeService.reloadTarget();
+    }
+
+    @Tool(name = "runJUnitPluginTests",
+          description = "Runs all JUnit Plug-in Tests in the specified project using the PDE launcher. Returns test results including pass/fail counts.",
+          type = "object")
+    public String runJUnitPluginTests(
+            @ToolParam(name = "projectName", description = "The exact Eclipse project name containing the plug-in test classes") String projectName,
+            @ToolParam(name = "timeout", description = "Maximum time in seconds to wait for test completion (default: 60)", required = false) String timeout)
+    {
+        int timeoutSeconds = Optional.ofNullable(timeout).map(Integer::parseInt).orElse(60);
+        return pdeService.runJUnitPluginTests(projectName, timeoutSeconds);
+    }
+
+    @Tool(name = "runJUnitPluginTestClass",
+          description = "Runs all JUnit Plug-in Tests in a specific class using the PDE launcher. Returns test results.",
+          type = "object")
+    public String runJUnitPluginTestClass(
+            @ToolParam(name = "projectName", description = "The exact Eclipse project name containing the test class") String projectName,
+            @ToolParam(name = "className", description = "The fully qualified class name (e.g., 'com.example.MyPluginTest')") String className,
+            @ToolParam(name = "timeout", description = "Maximum time in seconds to wait for test completion (default: 60)", required = false) String timeout)
+    {
+        int timeoutSeconds = Optional.ofNullable(timeout).map(Integer::parseInt).orElse(60);
+        return pdeService.runJUnitPluginTestClass(projectName, className, timeoutSeconds);
+    }
+}

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/PDEService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/PDEService.java
@@ -1,0 +1,470 @@
+package com.github.gradusnikov.eclipse.assistai.mcp.services;
+
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.e4.core.di.annotations.Creatable;
+import org.eclipse.e4.ui.di.UISynchronize;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.junit.JUnitCore;
+import org.eclipse.jdt.junit.TestRunListener;
+import org.eclipse.jdt.junit.model.ITestCaseElement;
+import org.eclipse.jdt.junit.model.ITestRunSession;
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
+import org.eclipse.pde.core.target.ITargetDefinition;
+import org.eclipse.pde.core.target.ITargetHandle;
+import org.eclipse.pde.core.target.ITargetPlatformService;
+import org.eclipse.pde.core.target.LoadTargetDefinitionJob;
+import org.eclipse.pde.launching.IPDELauncherConstants;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * Service providing PDE (Plugin Development Environment) related operations:
+ * target platform management and JUnit Plug-in Test execution.
+ */
+@Creatable
+@Singleton
+public class PDEService
+{
+    @Inject
+    private ILog logger;
+
+    @Inject
+    private UISynchronize sync;
+
+    // -------------------------------------------------------------------------
+    // Target platform
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a description of the currently active target platform.
+     * If the workspace is using the running platform (no explicit target set),
+     * returns a message saying so.
+     */
+    public String getActiveTarget()
+    {
+        try
+        {
+            ITargetPlatformService service = getTargetPlatformService();
+            ITargetHandle handle = service.getWorkspaceTargetHandle();
+
+            if ( handle == null )
+            {
+                return "Active target: <running platform> (no explicit target file set)";
+            }
+
+            ITargetDefinition definition = handle.getTargetDefinition();
+            String name = definition.getName() != null ? definition.getName() : "<unnamed>";
+
+            StringBuilder sb = new StringBuilder();
+            sb.append( "Active target: " ).append( name ).append( "\n" );
+            sb.append( "Memento: " ).append( handle.getMemento() ).append( "\n" );
+            sb.append( "Exists: " ).append( handle.exists() ).append( "\n" );
+            sb.append( "Resolved: " ).append( definition.isResolved() ).append( "\n" );
+
+            if ( definition.isResolved() )
+            {
+                var bundles = definition.getBundles();
+                sb.append( "Bundle count: " ).append( bundles != null ? bundles.length : 0 ).append( "\n" );
+            }
+
+            return sb.toString();
+        }
+        catch ( CoreException e )
+        {
+            return "Error getting active target: " + e.getMessage();
+        }
+    }
+
+    /**
+     * Sets the active target platform to the given workspace-relative target file path
+     * (e.g. "MyProject/my.target"). The job runs asynchronously; this method waits
+     * up to 120 seconds for it to complete.
+     *
+     * @param targetFilePath workspace-relative path to the .target file
+     */
+    public String setActiveTarget( String targetFilePath )
+    {
+        Objects.requireNonNull( targetFilePath, "Target file path cannot be null" );
+
+        try
+        {
+            IWorkspace workspace = ResourcesPlugin.getWorkspace();
+            IFile file = workspace.getRoot().getFile( new Path( targetFilePath ) );
+
+            if ( !file.exists() )
+            {
+                return "Error: Target file not found in workspace: " + targetFilePath;
+            }
+
+            ITargetPlatformService service = getTargetPlatformService();
+            ITargetHandle handle = service.getTarget( file );
+            ITargetDefinition definition = handle.getTargetDefinition();
+
+            CountDownLatch latch = new CountDownLatch( 1 );
+            String[] result = { null };
+
+            LoadTargetDefinitionJob.load( definition, new JobChangeAdapter()
+            {
+                @Override
+                public void done( IJobChangeEvent event )
+                {
+                    result[0] = event.getResult().isOK()
+                        ? "Target platform set to: " + definition.getName() + " (" + targetFilePath + ")"
+                        : "Error setting target platform: " + event.getResult().getMessage();
+                    latch.countDown();
+                }
+            } );
+
+            boolean completed = latch.await( 120, TimeUnit.SECONDS );
+            if ( !completed )
+            {
+                return "Error: Timed out waiting for target platform to load.";
+            }
+            return result[0];
+        }
+        catch ( Exception e )
+        {
+            return "Error setting active target: " + e.getMessage();
+        }
+    }
+
+    /**
+     * Reloads (resolves) the currently active target platform.
+     * Should be called after modifying the active .target file.
+     */
+    public String reloadTarget()
+    {
+        try
+        {
+            ITargetPlatformService service = getTargetPlatformService();
+            ITargetHandle handle = service.getWorkspaceTargetHandle();
+
+            if ( handle == null )
+            {
+                return "Error: No explicit target platform is set. Nothing to reload.";
+            }
+
+            ITargetDefinition definition = handle.getTargetDefinition();
+            CountDownLatch latch = new CountDownLatch( 1 );
+            String[] result = { null };
+
+            LoadTargetDefinitionJob.load( definition, new JobChangeAdapter()
+            {
+                @Override
+                public void done( IJobChangeEvent event )
+                {
+                    result[0] = event.getResult().isOK()
+                        ? "Target platform reloaded: " + definition.getName()
+                        : "Error reloading target platform: " + event.getResult().getMessage();
+                    latch.countDown();
+                }
+            } );
+
+            boolean completed = latch.await( 120, TimeUnit.SECONDS );
+            if ( !completed )
+            {
+                return "Error: Timed out waiting for target platform to reload.";
+            }
+            return result[0];
+        }
+        catch ( Exception e )
+        {
+            return "Error reloading target: " + e.getMessage();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // JUnit Plug-in Test
+    // -------------------------------------------------------------------------
+
+    /**
+     * Runs all JUnit Plug-in Tests in the given project.
+     */
+    public String runJUnitPluginTests( String projectName, Integer timeout )
+    {
+        Objects.requireNonNull( projectName, "Project name cannot be null" );
+        if ( projectName.isEmpty() )
+        {
+            throw new IllegalArgumentException( "Project name cannot be empty" );
+        }
+        if ( timeout == null || timeout <= 0 )
+        {
+            timeout = 120;
+        }
+
+        try
+        {
+            IJavaProject javaProject = getJavaProject( projectName );
+            return launchJUnitPluginTests( javaProject, null, null, timeout );
+        }
+        catch ( IllegalArgumentException | CoreException e )
+        {
+            return "Error running plug-in tests: " + e.getMessage();
+        }
+    }
+
+    /**
+     * Runs JUnit Plug-in Tests for a specific class.
+     */
+    public String runJUnitPluginTestClass( String projectName, String className, Integer timeout )
+    {
+        Objects.requireNonNull( projectName, "Project name cannot be null" );
+        Objects.requireNonNull( className, "Class name cannot be null" );
+        if ( timeout == null || timeout <= 0 )
+        {
+            timeout = 120;
+        }
+
+        try
+        {
+            IJavaProject javaProject = getJavaProject( projectName );
+            IType type = javaProject.findType( className );
+            if ( type == null )
+            {
+                return "Error: Class '" + className + "' not found in project '" + projectName + "'.";
+            }
+            return launchJUnitPluginTests( javaProject, null, type, timeout );
+        }
+        catch ( IllegalArgumentException | CoreException e )
+        {
+            return "Error running plug-in tests: " + e.getMessage();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private String launchJUnitPluginTests( IJavaProject javaProject, Object packageFragment,
+                                            IType testClass, int timeout )
+    {
+        CountDownLatch latch = new CountDownLatch( 1 );
+        UnitTestService.TestRunResult[] testRunResults = new UnitTestService.TestRunResult[1];
+
+        TestRunListener listener = new TestRunListener()
+        {
+            private UnitTestService.TestRunResult currentRun = null;
+
+            @Override
+            public void sessionStarted( ITestRunSession session )
+            {
+                currentRun = new UnitTestService.TestRunResult( session.getTestRunName() );
+            }
+
+            @Override
+            public void sessionFinished( ITestRunSession session )
+            {
+                testRunResults[0] = currentRun;
+                latch.countDown();
+            }
+
+            @Override
+            public void testCaseFinished( ITestCaseElement testCaseElement )
+            {
+                if ( currentRun != null )
+                {
+                    String clazz = testCaseElement.getTestClassName();
+                    String testName = testCaseElement.getTestMethodName();
+                    String status = testCaseElement.getTestResult( true ).toString();
+                    String message = testCaseElement.getFailureTrace() != null
+                        ? testCaseElement.getFailureTrace().getTrace() : "";
+                    double time = testCaseElement.getElapsedTimeInSeconds();
+                    currentRun.addTestResult( new UnitTestService.TestResult( clazz, testName, status, message, time ) );
+                }
+            }
+        };
+
+        JUnitCore.addTestRunListener( listener );
+
+        try
+        {
+            ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
+            // PDE JUnit Plug-in Test launch config type
+            ILaunchConfigurationType type = launchManager.getLaunchConfigurationType(
+                "org.eclipse.pde.ui.JunitLaunchConfig" );
+
+            if ( type == null )
+            {
+                return "Error: PDE JUnit Plug-in Test launch configuration type not found. "
+                    + "Ensure org.eclipse.pde.ui is available in the running Eclipse instance.";
+            }
+
+            String launchName = buildLaunchName( javaProject, testClass );
+            ILaunchConfiguration existing = findExistingLaunchConfig( launchManager, launchName );
+            ILaunchConfigurationWorkingCopy workingCopy;
+            if ( existing != null )
+            {
+                workingCopy = existing.getWorkingCopy();
+            }
+            else
+            {
+                workingCopy = type.newInstance( null, launchName );
+            }
+
+            workingCopy.setAttribute( IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME,
+                javaProject.getElementName() );
+
+            if ( testClass != null )
+            {
+                workingCopy.setAttribute( IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME,
+                    testClass.getFullyQualifiedName() );
+                workingCopy.setAttribute( "org.eclipse.jdt.junit.CONTAINER", "" );
+            }
+            else
+            {
+                workingCopy.setAttribute( IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, "" );
+                // CONTAINER must be the Java element handle identifier for the project:
+                // "=<projectName>" is the format JDT JUnit launcher expects
+                workingCopy.setAttribute( "org.eclipse.jdt.junit.CONTAINER",
+                    javaProject.getHandleIdentifier() );
+            }
+
+            // Detect JUnit version
+            workingCopy.setAttribute( "org.eclipse.jdt.junit.TEST_KIND",
+                detectJUnitTestKind( javaProject ) );
+
+            // Set a fixed workspace data dir so the PDE launcher never shows
+            // the "Select a workspace" dialog interactively
+            String testWorkspace = System.getProperty( "java.io.tmpdir" )
+                + java.io.File.separator + "pde-test-workspace-"
+                + javaProject.getElementName();
+            workingCopy.setAttribute( IPDELauncherConstants.LOCATION, testWorkspace );
+            workingCopy.setAttribute( IPDELauncherConstants.DOCLEAR, false );
+
+            ILaunchConfiguration configuration = workingCopy.doSave();
+
+            CoreException[] launchError = new CoreException[1];
+            sync.syncExec( () -> {
+                try
+                {
+                    configuration.launch( ILaunchManager.RUN_MODE, new NullProgressMonitor() );
+                }
+                catch ( CoreException e )
+                {
+                    launchError[0] = e;
+                    logger.log( org.eclipse.core.runtime.Status.error( "Error launching plug-in tests", e ) );
+                }
+            } );
+
+            if ( launchError[0] != null )
+            {
+                return "Error launching plug-in tests: " + launchError[0].getMessage();
+            }
+
+            boolean completed = latch.await( timeout, TimeUnit.SECONDS );
+            if ( !completed )
+            {
+                return "Error: Test execution timed out after " + timeout + " seconds.";
+            }
+            if ( testRunResults[0] == null )
+            {
+                return "Error: No test results collected. The test run may have failed to start.";
+            }
+            return testRunResults[0].toString();
+        }
+        catch ( Exception e )
+        {
+            logger.error( "Error running plug-in tests", e );
+            return "Error running plug-in tests: " + e.getMessage();
+        }
+        finally
+        {
+            JUnitCore.removeTestRunListener( listener );
+        }
+    }
+
+    private String buildLaunchName( IJavaProject project, IType testClass )
+    {
+        String base = "AssistAI-PDE-" + project.getElementName();
+        if ( testClass != null )
+        {
+            base += "-" + testClass.getElementName();
+        }
+        return base;
+    }
+
+    private ILaunchConfiguration findExistingLaunchConfig( ILaunchManager manager, String name )
+        throws CoreException
+    {
+        for ( ILaunchConfiguration config : manager.getLaunchConfigurations() )
+        {
+            if ( config.getName().equals( name ) )
+            {
+                return config;
+            }
+        }
+        return null;
+    }
+
+    private IJavaProject getJavaProject( String projectName ) throws CoreException
+    {
+        IWorkspace workspace = ResourcesPlugin.getWorkspace();
+        var project = workspace.getRoot().getProject( projectName );
+        if ( !project.exists() )
+        {
+            throw new IllegalArgumentException( "Project not found: " + projectName );
+        }
+        return JavaCore.create( project );
+    }
+
+    private String detectJUnitTestKind( IJavaProject javaProject ) throws JavaModelException
+    {
+        IType jupiterTest = javaProject.findType( "org.junit.jupiter.api.Test" );
+        if ( jupiterTest != null )
+        {
+            for ( var entry : javaProject.getResolvedClasspath( true ) )
+            {
+                String path = entry.getPath().toString();
+                if ( path.contains( "junit-jupiter-api" ) )
+                {
+                    if ( path.matches( ".*junit-jupiter-api[_-]6\\..*" ) )
+                    {
+                        return "org.eclipse.jdt.junit.loader.junit6";
+                    }
+                    break;
+                }
+            }
+            return "org.eclipse.jdt.junit.loader.junit5";
+        }
+        if ( javaProject.findType( "org.junit.Test" ) != null )
+        {
+            return "org.eclipse.jdt.junit.loader.junit4";
+        }
+        return "org.eclipse.jdt.junit.loader.junit5";
+    }
+
+    private ITargetPlatformService getTargetPlatformService()
+    {
+        var serviceRef = org.eclipse.core.runtime.Platform.getBundle( "org.eclipse.pde.core" )
+            .getBundleContext()
+            .getServiceReference( ITargetPlatformService.class );
+        if ( serviceRef == null )
+        {
+            throw new IllegalStateException( "ITargetPlatformService is not available" );
+        }
+        return org.eclipse.core.runtime.Platform.getBundle( "org.eclipse.pde.core" )
+            .getBundleContext()
+            .getService( serviceRef );
+    }
+}

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/META-INF/MANIFEST.MF
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/META-INF/MANIFEST.MF
@@ -17,6 +17,7 @@ Require-Bundle: junit-jupiter-api,
  junit-platform-commons,
  org.eclipse.jdt.core,
  org.eclipse.jdt.launching,
+ org.eclipse.pde.core,
  slf4j.api
 Automatic-Module-Name: com.github.gradusnikov.eclipse.plugin.assistai.main.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-23

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/servers/PDEMcpServerTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/servers/PDEMcpServerTest.java
@@ -1,0 +1,160 @@
+package com.github.gradusnikov.eclipse.plugin.assistai.mcp.servers;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.ILogListener;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.EclipseContextFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.ui.di.UISynchronize;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.Bundle;
+
+import com.github.gradusnikov.eclipse.assistai.mcp.servers.PDEMcpServer;
+
+/**
+ * Tests for PDEMcpServer â focuses on parameter handling and delegation.
+ * Methods that require a live PDE runtime are skipped via {@code assumeTrue}.
+ */
+public class PDEMcpServerTest
+{
+    private PDEMcpServer server;
+
+    @BeforeEach
+    public void setUp()
+    {
+        IEclipseContext context = EclipseContextFactory.create();
+
+        context.set( ILog.class, new ILog()
+        {
+            @Override
+            public void removeLogListener( ILogListener listener ) {}
+
+            @Override
+            public void log( IStatus status )
+            {
+                System.out.println( status.getMessage() );
+                if ( status.getException() != null )
+                {
+                    status.getException().printStackTrace();
+                }
+            }
+
+            @Override
+            public Bundle getBundle() { return null; }
+
+            @Override
+            public void addLogListener( ILogListener listener ) {}
+        } );
+
+        context.set( UISynchronize.class, new UISynchronize()
+        {
+            @Override
+            public void syncExec( Runnable runnable ) { runnable.run(); }
+
+            @Override
+            public void asyncExec( Runnable runnable ) { runnable.run(); }
+
+            @Override
+            protected boolean isUIThread( Thread thread ) { return true; }
+
+            @Override
+            protected void showBusyWhile( Runnable runnable ) { runnable.run(); }
+
+            @Override
+            protected boolean dispatchEvents() { return false; }
+        } );
+
+        server = ContextInjectionFactory.make( PDEMcpServer.class, context );
+    }
+
+    @Test
+    public void testGetActiveTarget_returnsNonNull()
+    {
+        try
+        {
+            String result = server.getActiveTarget();
+            assertNotNull( result, "getActiveTarget should not return null" );
+        }
+        catch ( Exception e )
+        {
+            assumeTrue( false, "Skipping: PDE runtime not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    @Test
+    public void testReloadTarget_returnsNonNull()
+    {
+        try
+        {
+            String result = server.reloadTarget();
+            assertNotNull( result, "reloadTarget should not return null" );
+        }
+        catch ( Exception e )
+        {
+            assumeTrue( false, "Skipping: PDE runtime not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    /**
+     * Verifies that a null timeout string is treated as the default (60 s) and
+     * that the call delegates to PDEService without throwing.
+     */
+    @Test
+    public void testRunJUnitPluginTests_nullTimeout_usesDefault()
+    {
+        try
+        {
+            // Non-existent project â will get an error string back, not an exception
+            String result = server.runJUnitPluginTests( "NonExistentProject_XYZ", null );
+            assertNotNull( result );
+            assertTrue( result.startsWith( "Error" ),
+                "Expected error for non-existent project, got: " + result );
+        }
+        catch ( IllegalStateException e )
+        {
+            assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    /**
+     * Verifies that an explicit timeout string is parsed and forwarded correctly.
+     */
+    @Test
+    public void testRunJUnitPluginTests_explicitTimeout_parsed()
+    {
+        try
+        {
+            String result = server.runJUnitPluginTests( "NonExistentProject_XYZ", "30" );
+            assertNotNull( result );
+            assertTrue( result.startsWith( "Error" ),
+                "Expected error for non-existent project, got: " + result );
+        }
+        catch ( IllegalStateException e )
+        {
+            assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    @Test
+    public void testRunJUnitPluginTestClass_nullTimeout_usesDefault()
+    {
+        try
+        {
+            String result = server.runJUnitPluginTestClass(
+                "NonExistentProject_XYZ", "com.example.MyTest", null );
+            assertNotNull( result );
+            assertTrue( result.startsWith( "Error" ),
+                "Expected error for non-existent project, got: " + result );
+        }
+        catch ( IllegalStateException e )
+        {
+            assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );
+        }
+    }
+}

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/PDEServicePluginTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/PDEServicePluginTest.java
@@ -1,0 +1,248 @@
+package com.github.gradusnikov.eclipse.plugin.assistai.mcp.services;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.EclipseContextFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.ui.di.UISynchronize;
+import org.eclipse.pde.core.target.ITargetDefinition;
+import org.eclipse.pde.core.target.ITargetHandle;
+import org.eclipse.pde.core.target.ITargetPlatformService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.util.tracker.ServiceTracker;
+
+import com.github.gradusnikov.eclipse.assistai.mcp.services.PDEService;
+
+/**
+ * JUnit Plug-in Test for {@link PDEService}.
+ * <p>
+ * Must be run as a <em>JUnit Plug-in Test</em> (PDE launcher) so that real
+ * OSGi services â {@link ITargetPlatformService}, {@link ILog},
+ * {@link UISynchronize} â are available from the running Eclipse instance.
+ */
+public class PDEServicePluginTest
+{
+    private PDEService service;
+    private BundleContext bundleContext;
+
+    @BeforeEach
+    public void setUp() throws Exception
+    {
+        bundleContext = FrameworkUtil.getBundle( PDEServicePluginTest.class ).getBundleContext();
+
+        // Obtain ILog from OSGi service registry
+        ServiceTracker<ILog, ILog> logTracker = new ServiceTracker<>( bundleContext, ILog.class, null );
+        logTracker.open();
+        ILog log = logTracker.getService();
+
+        IEclipseContext context = EclipseContextFactory.getServiceContext( bundleContext );
+
+        // Provide a no-op UISynchronize that runs everything inline (safe in test thread)
+        context.set( UISynchronize.class, new UISynchronize()
+        {
+            @Override
+            public void syncExec( Runnable runnable ) { runnable.run(); }
+
+            @Override
+            public void asyncExec( Runnable runnable ) { runnable.run(); }
+
+            @Override
+            protected boolean isUIThread( Thread thread ) { return false; }
+
+            @Override
+            protected void showBusyWhile( Runnable runnable ) { runnable.run(); }
+
+            @Override
+            protected boolean dispatchEvents() { return false; }
+        } );
+
+        if ( log != null )
+        {
+            context.set( ILog.class, log );
+        }
+
+        service = ContextInjectionFactory.make( PDEService.class, context );
+    }
+
+    // -------------------------------------------------------------------------
+    // getActiveTarget
+    // -------------------------------------------------------------------------
+
+    /**
+     * With a live PDE runtime, {@code getActiveTarget()} must always return a
+     * non-null, non-empty string â either the name of the active target or the
+     * "running platform" fallback message.
+     */
+    @Test
+    public void testGetActiveTarget_returnsNonEmptyString()
+    {
+        String result = service.getActiveTarget();
+        assertNotNull( result, "getActiveTarget must not return null" );
+        assertTrue( !result.isEmpty(), "getActiveTarget must not return an empty string" );
+    }
+
+    @Test
+    public void testGetActiveTarget_containsExpectedKeyword()
+    {
+        String result = service.getActiveTarget();
+        // Must start with "Active target:" or "Error getting active target:"
+        assertTrue(
+            result.startsWith( "Active target:" ) || result.startsWith( "Error getting active target:" ),
+            "Unexpected getActiveTarget output: " + result );
+    }
+
+    // -------------------------------------------------------------------------
+    // setActiveTarget â input validation (no actual .target file needed)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testSetActiveTarget_nullPath_throwsNPE()
+    {
+        assertThrows( NullPointerException.class,
+            () -> service.setActiveTarget( null ) );
+    }
+
+    @Test
+    public void testSetActiveTarget_missingFile_returnsErrorString()
+    {
+        String result = service.setActiveTarget( "/NonExistentProject/does-not-exist.target" );
+        assertNotNull( result );
+        assertTrue( result.startsWith( "Error" ),
+            "Expected error message for missing .target file, got: " + result );
+    }
+
+    // -------------------------------------------------------------------------
+    // reloadTarget
+    // -------------------------------------------------------------------------
+
+    /**
+     * Either the active target is reloaded successfully, or there is no
+     * explicit target set â both cases must yield a non-empty string.
+     */
+    @Test
+    public void testReloadTarget_returnsNonEmptyString()
+    {
+        String result = service.reloadTarget();
+        assertNotNull( result );
+        assertTrue( !result.isEmpty(), "reloadTarget must not return an empty string" );
+    }
+
+    @Test
+    public void testReloadTarget_outputIsCoherent()
+    {
+        String result = service.reloadTarget();
+        // Must be one of the three known prefixes
+        assertTrue(
+            result.startsWith( "Target platform reloaded:" )
+                || result.startsWith( "Error: No explicit target platform" )
+                || result.startsWith( "Error reloading target:" )
+                || result.startsWith( "Error: Timed out" ),
+            "Unexpected reloadTarget output: " + result );
+    }
+
+    // -------------------------------------------------------------------------
+    // runJUnitPluginTests â input validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testRunJUnitPluginTests_nullProjectName_throwsNPE()
+    {
+        assertThrows( NullPointerException.class,
+            () -> service.runJUnitPluginTests( null, 60 ) );
+    }
+
+    @Test
+    public void testRunJUnitPluginTests_emptyProjectName_throwsIllegalArgument()
+    {
+        assertThrows( IllegalArgumentException.class,
+            () -> service.runJUnitPluginTests( "", 60 ) );
+    }
+
+    @Test
+    public void testRunJUnitPluginTests_nonExistentProject_returnsErrorString()
+    {
+        String result = service.runJUnitPluginTests( "NonExistentProject_PDEPlugin", 10 );
+        assertNotNull( result );
+        assertTrue( result.startsWith( "Error" ),
+            "Expected error for non-existent project, got: " + result );
+    }
+
+    // -------------------------------------------------------------------------
+    // runJUnitPluginTestClass â input validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testRunJUnitPluginTestClass_nullProjectName_throwsNPE()
+    {
+        assertThrows( NullPointerException.class,
+            () -> service.runJUnitPluginTestClass( null, "com.example.MyTest", 60 ) );
+    }
+
+    @Test
+    public void testRunJUnitPluginTestClass_nullClassName_throwsNPE()
+    {
+        assertThrows( NullPointerException.class,
+            () -> service.runJUnitPluginTestClass( "SomeProject", null, 60 ) );
+    }
+
+    @Test
+    public void testRunJUnitPluginTestClass_nonExistentProject_returnsErrorString()
+    {
+        String result = service.runJUnitPluginTestClass(
+            "NonExistentProject_PDEPlugin", "com.example.MyTest", 10 );
+        assertNotNull( result );
+        assertTrue( result.startsWith( "Error" ),
+            "Expected error for non-existent project, got: " + result );
+    }
+
+    // -------------------------------------------------------------------------
+    // ITargetPlatformService availability
+    // -------------------------------------------------------------------------
+
+    /**
+     * Sanity-check: verifies that {@link ITargetPlatformService} is actually
+     * resolvable via {@code org.eclipse.pde.core} bundle in this OSGi runtime.
+     * If this test fails, the PDE bundle is not part of the launch configuration.
+     */
+    @Test
+    public void testTargetPlatformServiceIsAvailable()
+    {
+        var pdeBundle = org.eclipse.core.runtime.Platform.getBundle( "org.eclipse.pde.core" );
+        assertNotNull( pdeBundle, "org.eclipse.pde.core bundle must be present in the launch" );
+
+        var ref = pdeBundle.getBundleContext().getServiceReference( ITargetPlatformService.class );
+        assertNotNull( ref, "ITargetPlatformService must be registered in the OSGi registry" );
+
+        ITargetPlatformService tps = pdeBundle.getBundleContext().getService( ref );
+        assertNotNull( tps, "ITargetPlatformService instance must be non-null" );
+    }
+
+    /**
+     * Verifies that the workspace target handle can be retrieved (may be null
+     * if no explicit target is set, which is also a valid state).
+     */
+    @Test
+    public void testWorkspaceTargetHandle_doesNotThrow() throws Exception
+    {
+        var pdeBundle = org.eclipse.core.runtime.Platform.getBundle( "org.eclipse.pde.core" );
+        var ref = pdeBundle.getBundleContext().getServiceReference( ITargetPlatformService.class );
+        ITargetPlatformService tps = pdeBundle.getBundleContext().getService( ref );
+
+        // getWorkspaceTargetHandle() returns null when using the running platform
+        ITargetHandle handle = tps.getWorkspaceTargetHandle();
+
+        if ( handle != null )
+        {
+            ITargetDefinition def = handle.getTargetDefinition();
+            assertNotNull( def, "Target definition must not be null when handle is non-null" );
+        }
+        // null handle is valid â means "running platform" is active
+    }
+}

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/PDEServiceTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/PDEServiceTest.java
@@ -1,0 +1,283 @@
+package com.github.gradusnikov.eclipse.plugin.assistai.mcp.services;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.ILogListener;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.EclipseContextFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.ui.di.UISynchronize;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.Bundle;
+
+import com.github.gradusnikov.eclipse.assistai.mcp.services.PDEService;
+
+public class PDEServiceTest
+{
+    private PDEService service;
+
+    @BeforeEach
+    public void setUp()
+    {
+        IEclipseContext context = EclipseContextFactory.create();
+
+        context.set( ILog.class, new ILog()
+        {
+            @Override
+            public void removeLogListener( ILogListener listener ) {}
+
+            @Override
+            public void log( IStatus status )
+            {
+                System.out.println( status.getMessage() );
+                if ( status.getException() != null )
+                {
+                    status.getException().printStackTrace();
+                }
+            }
+
+            @Override
+            public Bundle getBundle() { return null; }
+
+            @Override
+            public void addLogListener( ILogListener listener ) {}
+        } );
+
+        context.set( UISynchronize.class, new UISynchronize()
+        {
+            @Override
+            public void syncExec( Runnable runnable ) { runnable.run(); }
+
+            @Override
+            public void asyncExec( Runnable runnable ) { runnable.run(); }
+
+            @Override
+            protected boolean isUIThread( Thread thread ) { return true; }
+
+            @Override
+            protected void showBusyWhile( Runnable runnable ) { runnable.run(); }
+
+            @Override
+            protected boolean dispatchEvents() { return false; }
+        } );
+
+        service = ContextInjectionFactory.make( PDEService.class, context );
+    }
+
+    // -------------------------------------------------------------------------
+    // getActiveTarget
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testGetActiveTarget_returnsSomething()
+    {
+        try
+        {
+            String result = service.getActiveTarget();
+            assertTrue( result != null && !result.isEmpty(),
+                "getActiveTarget should return a non-empty string" );
+        }
+        catch ( Exception e )
+        {
+            // Outside a PDE runtime, platform services may be absent â skip
+            assumeTrue( false, "Skipping: PDE service not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // setActiveTarget â input validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testSetActiveTarget_nullPath_throwsNPE()
+    {
+        assertThrows( NullPointerException.class,
+            () -> service.setActiveTarget( null ) );
+    }
+
+    @Test
+    public void testSetActiveTarget_nonExistentFile_returnsError()
+    {
+        try
+        {
+            String result = service.setActiveTarget( "/DoesNotExist/missing.target" );
+            assertTrue( result.startsWith( "Error" ),
+                "Expected an error message for a missing target file, got: " + result );
+        }
+        catch ( IllegalStateException e )
+        {
+            // ITargetPlatformService not available outside PDE runtime â acceptable
+            assumeTrue( false, "Skipping: PDE service not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // reloadTarget â no explicit target set
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testReloadTarget_whenNoPlatformService_returnsErrorOrSkips()
+    {
+        try
+        {
+            String result = service.reloadTarget();
+            // With no target set the method returns an error string; with one set it
+            // would try to reload â either outcome is a non-empty string.
+            assertTrue( result != null && !result.isEmpty(),
+                "reloadTarget should return a non-empty string" );
+        }
+        catch ( IllegalStateException e )
+        {
+            assumeTrue( false, "Skipping: PDE service not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // runJUnitPluginTests â input validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testRunJUnitPluginTests_nullProjectName_throwsNPE()
+    {
+        assertThrows( NullPointerException.class,
+            () -> service.runJUnitPluginTests( null, 60 ) );
+    }
+
+    @Test
+    public void testRunJUnitPluginTests_emptyProjectName_throwsIllegalArgument()
+    {
+        assertThrows( IllegalArgumentException.class,
+            () -> service.runJUnitPluginTests( "", 60 ) );
+    }
+
+    @Test
+    public void testRunJUnitPluginTests_nonExistentProject_returnsError()
+    {
+        try
+        {
+            String result = service.runJUnitPluginTests( "NonExistentProject_XYZ", 60 );
+            assertTrue( result.startsWith( "Error" ),
+                "Expected an error message for non-existent project, got: " + result );
+        }
+        catch ( IllegalStateException e )
+        {
+            assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    @Test
+    public void testRunJUnitPluginTests_nullTimeout_usesDefault()
+    {
+        try
+        {
+            // Should not throw; null timeout is normalised internally to 120
+            String result = service.runJUnitPluginTests( "NonExistentProject_XYZ", null );
+            assertTrue( result.startsWith( "Error" ),
+                "Expected an error for non-existent project" );
+        }
+        catch ( IllegalStateException e )
+        {
+            assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // runJUnitPluginTestClass â input validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testRunJUnitPluginTestClass_nullProjectName_throwsNPE()
+    {
+        assertThrows( NullPointerException.class,
+            () -> service.runJUnitPluginTestClass( null, "com.example.MyTest", 60 ) );
+    }
+
+    @Test
+    public void testRunJUnitPluginTestClass_nullClassName_throwsNPE()
+    {
+        assertThrows( NullPointerException.class,
+            () -> service.runJUnitPluginTestClass( "SomeProject", null, 60 ) );
+    }
+
+    @Test
+    public void testRunJUnitPluginTestClass_nonExistentProject_returnsError()
+    {
+        try
+        {
+            String result = service.runJUnitPluginTestClass( "NonExistentProject_XYZ", "com.example.MyTest", 60 );
+            assertTrue( result.startsWith( "Error" ),
+                "Expected an error message for non-existent project, got: " + result );
+        }
+        catch ( IllegalStateException | IllegalArgumentException e )
+        {
+            assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    /**
+     * Integration test: launch a specific test class via the PDE JUnit launcher.
+     * Verifies that IPDELauncherConstants.LOCATION suppresses the workspace-selection
+     * dialog and that the launcher reports results correctly.
+     *
+     * This test requires a running Eclipse instance with the test project open.
+     */
+    @Test
+    public void testRunJUnitPluginTestClass_realProject_passes()
+    {
+        try
+        {
+            String result = service.runJUnitPluginTestClass(
+                "com.github.gradusnikov.eclipse.plugin.assistai.main.tests",
+                "com.github.gradusnikov.eclipse.plugin.assistai.mcp.services.PDEServiceTest",
+                120 );
+            System.out.println( "runJUnitPluginTestClass result: " + result );
+            // Skip if the test project is not available in this environment
+            assumeTrue( !result.contains( "Project not found" ),
+                "Skipping: test project not open in this environment" );
+            assertTrue( result.contains( "Passed" ) || result.contains( "passed" ),
+                "Expected passing tests in result, got: " + result );
+        }
+        catch ( IllegalStateException | IllegalArgumentException e )
+        {
+            assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    /**
+     * Integration test: launch all tests in the project via the PDE JUnit launcher.
+     * Verifies that the CONTAINER handle-identifier format (=projectName) is correct
+     * and the launcher starts without "input element does not exist" error.
+     *
+     * This test requires a running Eclipse instance with the test project open.
+     */
+    @Test
+    public void testRunJUnitPluginTests_realProject_launches()
+    {
+        try
+        {
+            String result = service.runJUnitPluginTests(
+                "com.github.gradusnikov.eclipse.plugin.assistai.main.tests",
+                120 );
+            System.out.println( "runJUnitPluginTests result: " + result );
+            // Skip if the test project is not available in this environment
+            assumeTrue( !result.contains( "Project not found" ),
+                "Skipping: test project not open in this environment" );
+            // Must not contain the "input element does not exist" error from the old path bug
+            assertTrue( !result.contains( "does not exist" ),
+                "Got 'does not exist' error - container format is wrong: " + result );
+            // Should either pass or time out (not a launch config error)
+            assertTrue( result.contains( "Passed" ) || result.contains( "passed" )
+                || result.contains( "timed out" ),
+                "Expected test results or timeout, got: " + result );
+        }
+        catch ( IllegalStateException | IllegalArgumentException e )
+        {
+            assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );
+        }
+    }
+}


### PR DESCRIPTION
This adds another MCP server but for plugin development, so it has stuff for handling targets (.target files, setting them) and it has the run unit Plugin tests also (so that 2 more run test methods besides the normal once)




- Add PDEService: getActiveTarget, setActiveTarget, reloadTarget, runJUnitPluginTests, runJUnitPluginTestClass; uses ITargetPlatformService and PDE JUnit launcher
- Add PDEMcpServer (@McpServer name='eclipse-pde') delegating to PDEService
- Register PDEMcpServer in McpServerBuiltins
- Add org.eclipse.pde.core to Require-Bundle in main and tests MANIFEST.MF
- Add PDEServiceTest and PDEMcpServerTest (unit tests with mock OSGi context)
- Add PDEServicePluginTest (JUnit Plug-in Test using real OSGi/PDE services)