### PR TITLE
Quickfix enhancements (able to execute a quick fix)

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/EclipseContextMcpServer.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/EclipseContextMcpServer.java
@@ -1,7 +1,6 @@
 package com.github.gradusnikov.eclipse.assistai.mcp.servers;
 
 import java.net.URI;
-import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/EclipseIntegrationsMcpServer.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/EclipseIntegrationsMcpServer.java
@@ -309,17 +309,7 @@ public class EclipseIntegrationsMcpServer
         return codeAnalysisService.findReferences(fullyQualifiedClassName, elementName);
     }
 
-    @Tool(name = "getQuickFixes", description = "Gets available quick fixes for compilation errors in a Java file. Shows problem details and suggested corrections for each error.", type = "object")
-    public String getQuickFixes(
-            @ToolParam(name = "projectName", description = "The name of the project containing the file", required = true) String projectName,
-            @ToolParam(name = "filePath", description = "The path to the Java file relative to the project root", required = true) String filePath,
-            @ToolParam(name = "lineNumber", description = "Optional line number to filter fixes for a specific error", required = false) String lineNumber)
-    {
-        return codeAnalysisService.getQuickFixes(projectName, filePath,
-                Optional.ofNullable(lineNumber).map(Integer::parseInt).orElse(null));
-    }
-
-    @Tool(name = "executeQuickFix", description = "Applies a specific quick fix proposal to a compilation problem. Use getCompilationErrors or getQuickFixes first to obtain the Marker ID and proposal index.", type = "object")
+    @Tool(name = "executeQuickFix", description = "Applies a specific quick fix proposal to a compilation problem. Use getCompilationErrors first to obtain the Marker ID and proposal index.", type = "object")
     public String executeQuickFix(
             @ToolParam(name = "markerId", description = "The Marker ID of the problem (from getCompilationErrors or getQuickFixes)", required = true) String markerId,
             @ToolParam(name = "proposalIndex", description = "The 0-based index of the quick fix proposal to apply (from the quick fixes list)", required = true) String proposalIndex)

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/EclipseIntegrationsMcpServer.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/EclipseIntegrationsMcpServer.java
@@ -319,6 +319,14 @@ public class EclipseIntegrationsMcpServer
                 Optional.ofNullable(lineNumber).map(Integer::parseInt).orElse(null));
     }
 
+    @Tool(name = "executeQuickFix", description = "Applies a specific quick fix proposal to a compilation problem. Use getCompilationErrors or getQuickFixes first to obtain the Marker ID and proposal index.", type = "object")
+    public String executeQuickFix(
+            @ToolParam(name = "markerId", description = "The Marker ID of the problem (from getCompilationErrors or getQuickFixes)", required = true) String markerId,
+            @ToolParam(name = "proposalIndex", description = "The 0-based index of the quick fix proposal to apply (from the quick fixes list)", required = true) String proposalIndex)
+    {
+        return codeAnalysisService.executeQuickFix(Long.parseLong(markerId), Integer.parseInt(proposalIndex));
+    }
+
     @Tool(name = "getImportSuggestions", description = "Finds import candidates for unresolved types in a Java file. Shows matching fully qualified names from the workspace for each unresolved type error.", type = "object")
     public String getImportSuggestions(
             @ToolParam(name = "projectName", description = "The name of the project containing the file", required = true) String projectName,

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeAnalysisService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeAnalysisService.java
@@ -353,24 +353,7 @@ public class CodeAnalysisService
                         }
                     }
 
-                    // Inline quick fix proposals â works for any marker type
-                    try
-                    {
-                        List<QuickFix> fixes = collectQuickFixes(marker);
-                        if (!fixes.isEmpty())
-                        {
-                            result.append("  - Quick fixes:\n");
-                            for (int i = 0; i < fixes.size(); i++)
-                            {
-                                result.append("    - [").append(i).append("] ")
-                                      .append(fixes.get(i).label()).append("\n");
-                            }
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        // Quick fix collection is best-effort
-                    }
+                    appendQuickFixBlock(marker, result, "  ");
                 }
                 
                 result.append("\n");
@@ -707,105 +690,47 @@ public class CodeAnalysisService
         }
     }
 
+
     /**
-     * Gets available quick fixes for compilation errors in a file.
-     * Uses Eclipse's JavaCorrectionProcessor to collect real IJavaCompletionProposal instances.
+     * Appends a quick-fix block for {@code marker} to {@code sb}.
+     * Produces numbered proposals with descriptions and a hint to the LLM to
+     * call {@code executeQuickFix} with the chosen index.
+     * Best-effort â any exception is silently swallowed.
      *
-     * @param projectName The project name
-     * @param filePath The file path relative to the project
-     * @param lineNumber Optional line number to filter fixes for
-     * @return A formatted string listing available quick fixes with proposal indices
+     * @param marker the problem marker
+     * @param sb     the builder to append to
+     * @param indent line prefix (e.g. {@code "  "} for two-space indent)
      */
-    public String getQuickFixes(String projectName, String filePath, Integer lineNumber)
+    private void appendQuickFixBlock(IMarker marker, StringBuilder sb, String indent)
     {
         try
         {
-            IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
-            if (!project.exists() || !project.isOpen())
+            List<QuickFix> fixes = collectQuickFixes(marker);
+            if (fixes.isEmpty())
             {
-                return "Error: Project '" + projectName + "' not found or not open.";
+                sb.append(indent).append("- Quick fixes: none available\n");
             }
-
-            IFile file = project.getFile(filePath);
-            if (!file.exists())
+            else
             {
-                return "Error: File '" + filePath + "' not found.";
-            }
-
-            IMarker[] markers = file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO);
-
-            var result = new StringBuilder();
-            result.append("# Quick Fixes for ").append(filePath).append("\n\n");
-
-            int fixCount = 0;
-            for (IMarker marker : markers)
-            {
-                Integer markerLine = (Integer) marker.getAttribute(IMarker.LINE_NUMBER);
-                if (lineNumber != null && markerLine != null && !lineNumber.equals(markerLine))
+                sb.append(indent).append("- Quick fixes (pass index to executeQuickFix):\n");
+                for (int i = 0; i < fixes.size(); i++)
                 {
-                    continue;
-                }
-
-                Integer severity = (Integer) marker.getAttribute(IMarker.SEVERITY);
-                String sevText = severity != null && severity == IMarker.SEVERITY_ERROR ? "ERROR" : "WARNING";
-                String message = (String) marker.getAttribute(IMarker.MESSAGE);
-
-                result.append("## ").append(sevText).append(" at line ").append(markerLine).append("\n");
-                result.append("Message: ").append(message).append("\n");
-                result.append("Marker ID: ").append(marker.getId()).append("\n");
-
-                var problemId = marker.getAttribute(IJavaModelMarker.ID);
-                if (problemId != null)
-                {
-                    result.append("Problem ID: ").append(problemId).append("\n");
-                }
-
-                try
-                {
-                    List<QuickFix> fixes = collectQuickFixes(marker);
-                    if (fixes.isEmpty())
+                    QuickFix fix = fixes.get(i);
+                    sb.append(indent).append("    - [").append(i).append("] ").append(fix.label());
+                    if (fix.description() != null && !fix.description().isBlank())
                     {
-                        result.append("No quick fixes available.\n");
+                        sb.append(" \u2013 ").append(fix.description());
                     }
-                    else
-                    {
-                        result.append("Quick fixes (use proposal index with executeQuickFix):\n");
-                        for (int i = 0; i < fixes.size(); i++)
-                        {
-                            QuickFix fix = fixes.get(i);
-                            result.append("  [").append(i).append("] ").append(fix.label());
-                            if (fix.description() != null && !fix.description().isBlank())
-                            {
-                                result.append(" â ").append(fix.description());
-                            }
-                            result.append("\n");
-                        }
-                    }
+                    sb.append("\n");
                 }
-                catch (Exception e)
-                {
-                    result.append("Could not retrieve quick fixes: ").append(e.getMessage()).append("\n");
-                }
-
-                result.append("\n");
-                fixCount++;
             }
-
-            if (fixCount == 0)
-            {
-                result.append("No problems found");
-                if (lineNumber != null) result.append(" at line ").append(lineNumber);
-                result.append(".\n");
-            }
-
-            return result.toString();
         }
         catch (Exception e)
         {
-            logger.error(e.getMessage(), e);
-            return "Error getting quick fixes: " + e.getMessage();
+            // quick fix collection is best-effort; skip silently
         }
     }
+
 
     /**
      * Unified quick fix descriptor â wraps either a JDT IJavaCompletionProposal

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeAnalysisService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeAnalysisService.java
@@ -30,6 +30,7 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.internal.corext.callhierarchy.CallHierarchy;
 import org.eclipse.jdt.internal.corext.callhierarchy.MethodWrapper;
+import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
 
 import com.github.gradusnikov.eclipse.assistai.services.AiIgnoreService;
 
@@ -309,7 +310,10 @@ public class CodeAnalysisService
                     result.append("- **").append(severityText).append("** at ").append(lineStr).append(": ")
                           .append(message).append("\n");
                     
-                    // If this is a Java problem, try to get more context
+                    // Emit the marker's unique ID so it can be referenced by executeQuickFix
+                    result.append("  - Marker ID: ").append(marker.getId()).append("\n");
+
+                    // Java-specific: emit internal problem ID
                     if (marker.getType().equals(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER)) 
                     {
                         var sourceId = marker.getAttribute(IJavaModelMarker.ID);
@@ -317,42 +321,55 @@ public class CodeAnalysisService
                         {
                             result.append("  - Problem ID: ").append(sourceId).append("\n");
                         }
-                        
-                        // Try to get source code snippet if line number is available
-                        if (lineNumber != null && marker.getResource() instanceof IFile) 
+                    }
+
+                    // Context snippet â any marker attached to an IFile with a line number
+                    if (lineNumber != null && marker.getResource() instanceof IFile ifile)
+                    {
+                        try 
                         {
-                            try 
+                            String fileContent = readFileContent(ifile);
+                            String[] lines = fileContent.split("\n");
+                            
+                            if (lineNumber > 0 && lineNumber <= lines.length) 
                             {
-                                IFile file = (IFile) marker.getResource();
-                                String fileContent = readFileContent(file);
-                                String[] lines = fileContent.split("\n");
-                                
-                                if (lineNumber > 0 && lineNumber <= lines.length) 
+                                int startLine = Math.max(1, lineNumber - 1);
+                                int endLine = Math.min(lines.length, lineNumber + 1);
+                                // Use a neutral fence (no language tag) for non-Java files
+                                String ext = ifile.getFileExtension();
+                                String lang = ext != null ? ext : "";
+                                result.append("  - Context:\n```").append(lang).append("\n");
+                                for (int i = startLine - 1; i < endLine; i++) 
                                 {
-                                    int startLine = Math.max(1, lineNumber - 1);
-                                    int endLine = Math.min(lines.length, lineNumber + 1);
-                                    
-                                    result.append("  - Context:\n```java\n");
-                                    for (int i = startLine - 1; i < endLine; i++) 
-                                    {
-                                        if (i == lineNumber - 1) 
-                                        {
-                                            result.append("> "); // Highlight the error line
-                                        }
-                                        else 
-                                        {
-                                            result.append("  ");
-                                        }
-                                        result.append(lines[i]).append("\n");
-                                    }
-                                    result.append("```\n");
+                                    result.append(i == lineNumber - 1 ? "> " : "  ");
+                                    result.append(lines[i]).append("\n");
                                 }
-                            } 
-                            catch (Exception e) 
+                                result.append("```\n");
+                            }
+                        } 
+                        catch (Exception e) 
+                        {
+                            // Skip context if we can't read the file
+                        }
+                    }
+
+                    // Inline quick fix proposals â works for any marker type
+                    try
+                    {
+                        List<QuickFix> fixes = collectQuickFixes(marker);
+                        if (!fixes.isEmpty())
+                        {
+                            result.append("  - Quick fixes:\n");
+                            for (int i = 0; i < fixes.size(); i++)
                             {
-                                // Skip context if we can't read the file
+                                result.append("    - [").append(i).append("] ")
+                                      .append(fixes.get(i).label()).append("\n");
                             }
                         }
+                    }
+                    catch (Exception e)
+                    {
+                        // Quick fix collection is best-effort
                     }
                 }
                 
@@ -692,11 +709,12 @@ public class CodeAnalysisService
 
     /**
      * Gets available quick fixes for compilation errors in a file.
+     * Uses Eclipse's JavaCorrectionProcessor to collect real IJavaCompletionProposal instances.
      *
      * @param projectName The project name
      * @param filePath The file path relative to the project
      * @param lineNumber Optional line number to filter fixes for
-     * @return A formatted string listing available quick fixes
+     * @return A formatted string listing available quick fixes with proposal indices
      */
     public String getQuickFixes(String projectName, String filePath, Integer lineNumber)
     {
@@ -714,7 +732,6 @@ public class CodeAnalysisService
                 return "Error: File '" + filePath + "' not found.";
             }
 
-            // Get problem markers for the file
             IMarker[] markers = file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO);
 
             var result = new StringBuilder();
@@ -735,36 +752,39 @@ public class CodeAnalysisService
 
                 result.append("## ").append(sevText).append(" at line ").append(markerLine).append("\n");
                 result.append("Message: ").append(message).append("\n");
+                result.append("Marker ID: ").append(marker.getId()).append("\n");
 
-                // Try to get quick fix proposals via JDT
+                var problemId = marker.getAttribute(IJavaModelMarker.ID);
+                if (problemId != null)
+                {
+                    result.append("Problem ID: ").append(problemId).append("\n");
+                }
+
                 try
                 {
-                    IJavaProject javaProject = JavaCore.create(project);
-                    ICompilationUnit cu = JavaCore.createCompilationUnitFrom(file);
-                    if (cu != null)
+                    List<QuickFix> fixes = collectQuickFixes(marker);
+                    if (fixes.isEmpty())
                     {
-                        // Get the problem ID from the marker
-                        var problemId = marker.getAttribute(IJavaModelMarker.ID);
-                        if (problemId != null)
+                        result.append("No quick fixes available.\n");
+                    }
+                    else
+                    {
+                        result.append("Quick fixes (use proposal index with executeQuickFix):\n");
+                        for (int i = 0; i < fixes.size(); i++)
                         {
-                            result.append("Problem ID: ").append(problemId).append("\n");
-                        }
-
-                        // List corrections using marker attributes
-                        var args = (String[]) marker.getAttribute("arguments");
-                        if (args != null && args.length > 0)
-                        {
-                            result.append("Suggestions:\n");
-                            for (String arg : args)
+                            QuickFix fix = fixes.get(i);
+                            result.append("  [").append(i).append("] ").append(fix.label());
+                            if (fix.description() != null && !fix.description().isBlank())
                             {
-                                result.append("  - ").append(arg).append("\n");
+                                result.append(" â ").append(fix.description());
                             }
+                            result.append("\n");
                         }
                     }
                 }
                 catch (Exception e)
                 {
-                    // Quick fix retrieval is best-effort
+                    result.append("Could not retrieve quick fixes: ").append(e.getMessage()).append("\n");
                 }
 
                 result.append("\n");
@@ -786,6 +806,217 @@ public class CodeAnalysisService
             return "Error getting quick fixes: " + e.getMessage();
         }
     }
+
+    /**
+     * Unified quick fix descriptor â wraps either a JDT IJavaCompletionProposal
+     * or a platform IMarkerResolution so both can be presented and applied uniformly.
+     */
+    private record QuickFix(String label, String description, java.util.function.Consumer<IMarker> applyFn)
+    {
+        void apply(IMarker marker) { applyFn.accept(marker); }
+    }
+
+    /**
+     * Executes a specific quick fix proposal for a problem marker.
+     *
+     * @param markerId      The marker ID as returned by getCompilationErrors or getQuickFixes
+     * @param proposalIndex The index of the proposal to apply (0-based, from the quick fixes list)
+     * @return Result message indicating success or failure
+     */
+    public String executeQuickFix(long markerId, int proposalIndex)
+    {
+        try
+        {
+            IMarker marker = findMarkerById(markerId);
+            if (marker == null)
+            {
+                return "Error: Marker with ID " + markerId + " not found. It may have been resolved already.";
+            }
+
+            List<QuickFix> fixes = collectQuickFixes(marker);
+            if (fixes.isEmpty())
+            {
+                return "Error: No quick fix proposals available for marker " + markerId + ".";
+            }
+            if (proposalIndex < 0 || proposalIndex >= fixes.size())
+            {
+                return "Error: Proposal index " + proposalIndex + " is out of range (0-" + (fixes.size() - 1) + ").";
+            }
+
+            QuickFix fix = fixes.get(proposalIndex);
+            fix.apply(marker);
+            return "Quick fix applied: \"" + fix.label() + "\" on marker " + markerId + ".";
+        }
+        catch (Exception e)
+        {
+            logger.error(e.getMessage(), e);
+            return "Error applying quick fix: " + e.getMessage();
+        }
+    }
+
+    /**
+     * Collects quick fix proposals for any problem marker using two mechanisms:
+     * 1. Platform IMarkerHelpRegistry (works for all marker types: JDT, PDE, m2e, build path, â¦)
+     * 2. JDT JavaCorrectionProcessor (Java-only, richer proposals; deduped against registry results)
+     */
+    private List<QuickFix> collectQuickFixes(IMarker marker)
+    {
+        List<QuickFix> fixes = new ArrayList<>();
+
+        // --- Mechanism 1: Platform IMarkerHelpRegistry (generic, all marker types) ---
+        try
+        {
+            org.eclipse.ui.ide.IDE.getMarkerHelpRegistry();  // touch to ensure registry is initialized
+            org.eclipse.ui.IMarkerHelpRegistry registry = org.eclipse.ui.ide.IDE.getMarkerHelpRegistry();
+            if (registry.hasResolutions(marker))
+            {
+                for (org.eclipse.ui.IMarkerResolution r : registry.getResolutions(marker))
+                {
+                    String label = r.getLabel();
+                    String desc = (r instanceof org.eclipse.ui.IMarkerResolution2 r2) ? r2.getDescription() : null;
+                    fixes.add(new QuickFix(label, desc, m -> r.run(m)));
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            // registry lookup is best-effort
+        }
+
+        // --- Mechanism 2: JDT JavaCorrectionProcessor (Java markers only, supplements registry) ---
+        try
+        {
+            if (marker.getType().equals(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER)
+                    && marker.getResource() instanceof IFile file)
+            {
+                ICompilationUnit cu = (ICompilationUnit) JavaCore.create(file);
+                if (cu != null && cu.exists())
+                {
+                    int id      = marker.getAttribute(IJavaModelMarker.ID, -1);
+                    int start   = marker.getAttribute(IMarker.CHAR_START, -1);
+                    int end     = marker.getAttribute(IMarker.CHAR_END, -1);
+                    boolean isError = marker.getAttribute(IMarker.SEVERITY, 0) == IMarker.SEVERITY_ERROR;
+                    String[] args = readMarkerArguments(marker);
+                    String markerType = marker.getType();
+
+                    if (start >= 0 && end >= 0)
+                    {
+                        org.eclipse.jdt.internal.ui.text.correction.ProblemLocation location =
+                            new org.eclipse.jdt.internal.ui.text.correction.ProblemLocation(
+                                start, end - start, id, args, isError, markerType);
+
+                        org.eclipse.jdt.internal.ui.text.correction.AssistContext context =
+                            new org.eclipse.jdt.internal.ui.text.correction.AssistContext(cu, start, end - start);
+
+                        List<IJavaCompletionProposal> jdtProposals = new ArrayList<>();
+                        org.eclipse.jdt.internal.ui.text.correction.JavaCorrectionProcessor.collectCorrections(
+                            context, new org.eclipse.jdt.ui.text.java.IProblemLocation[]{ location }, jdtProposals);
+
+                        jdtProposals.sort((a, b) -> Integer.compare(b.getRelevance(), a.getRelevance()));
+
+                        // Add JDT proposals that aren't already covered by the registry (dedupe by label)
+                        java.util.Set<String> existingLabels = new java.util.HashSet<>();
+                        fixes.forEach(f -> existingLabels.add(f.label()));
+
+                        for (IJavaCompletionProposal p : jdtProposals)
+                        {
+                            String label = p.getDisplayString();
+                            if (existingLabels.add(label))  // true if newly added
+                            {
+                                fixes.add(new QuickFix(label, null, m -> applyJdtProposal(p, m)));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            // JDT supplement is best-effort
+        }
+
+        return fixes;
+    }
+
+    /** Applies a JDT IJavaCompletionProposal headlessly. */
+    private void applyJdtProposal(IJavaCompletionProposal proposal, IMarker marker)
+    {
+        try
+        {
+            if (proposal instanceof org.eclipse.jdt.core.manipulation.ICUCorrectionProposal icp)
+            {
+                icp.getTextChange().perform(new NullProgressMonitor());
+            }
+            else
+            {
+                // Fallback via TextFileDocumentProvider
+                IFile file = (IFile) marker.getResource();
+                org.eclipse.ui.editors.text.TextFileDocumentProvider provider =
+                    new org.eclipse.ui.editors.text.TextFileDocumentProvider();
+                provider.connect(file);
+                try
+                {
+                    org.eclipse.jface.text.IDocument doc = provider.getDocument(file);
+                    if (doc == null)
+                    {
+                        throw new RuntimeException("Could not open document for " + file.getFullPath());
+                    }
+                    proposal.apply(doc);
+                    provider.saveDocument(new NullProgressMonitor(), file, doc, true);
+                }
+                finally
+                {
+                    provider.disconnect(file);
+                }
+            }
+        }
+        catch (RuntimeException re)
+        {
+            throw re;
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Reads the raw problem arguments from a marker. */
+    private String[] readMarkerArguments(IMarker marker)
+    {
+        try
+        {
+            Object argsAttr = marker.getAttribute("arguments");
+            if (argsAttr instanceof String[] sa)   return sa;
+            if (argsAttr instanceof String s && !s.isBlank()) return s.split("#");
+        }
+        catch (Exception ex) { /* ignore */ }
+        return new String[0];
+    }
+
+    /**
+     * Finds an IMarker by its numeric ID across the entire workspace.
+     */
+    private IMarker findMarkerById(long markerId)
+    {
+        try
+        {
+            IMarker[] all = ResourcesPlugin.getWorkspace().getRoot()
+                .findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
+            for (IMarker m : all)
+            {
+                if (m.getId() == markerId)
+                {
+                    return m;
+                }
+            }
+        }
+        catch (CoreException e)
+        {
+            // ignore
+        }
+        return null;
+    }
+
 
     /**
      * Gets import suggestions for unresolved types in a compilation unit.

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeAnalysisService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeAnalysisService.java
@@ -770,7 +770,15 @@ public class CodeAnalysisService
 
             QuickFix fix = fixes.get(proposalIndex);
             fix.apply(marker);
-            return "Quick fix applied: \"" + fix.label() + "\" on marker " + markerId + ".";
+
+            if (marker.getResource() instanceof IFile file)
+            {
+                saveFileBuffer(file);
+                file.refreshLocal(IResource.DEPTH_ZERO, new NullProgressMonitor());
+            }
+
+            String status = marker.exists() ? "applied (marker still present)" : "applied and marker resolved";
+            return "Quick fix applied: \"" + fix.label() + "\" on marker " + markerId + " - " + status;
         }
         catch (Exception e)
         {
@@ -780,40 +788,26 @@ public class CodeAnalysisService
     }
 
     /**
-     * Collects quick fix proposals for any problem marker using two mechanisms:
-     * 1. Platform IMarkerHelpRegistry (works for all marker types: JDT, PDE, m2e, build path, â¦)
-     * 2. JDT JavaCorrectionProcessor (Java-only, richer proposals; deduped against registry results)
+     * Collects quick fix proposals for any problem marker.
+     *
+     * Java markers: calls JavaCorrectionProcessor directly. This produces ICUCorrectionProposal
+     * instances that apply and save headlessly without needing an open editor.
+     * Skips IMarkerHelpRegistry for Java markers because CorrectionMarkerResolution.run()
+     * calls JavaUI.openInEditor() and silently does nothing when no editor is open.
+     *
+     * Non-Java markers (PDE, m2e, build-path, etc.): uses IMarkerHelpRegistry and run().
      */
     private List<QuickFix> collectQuickFixes(IMarker marker)
     {
         List<QuickFix> fixes = new ArrayList<>();
+        java.util.Set<String> seenLabels = new java.util.HashSet<>();
 
-        // --- Mechanism 1: Platform IMarkerHelpRegistry (generic, all marker types) ---
-        try
-        {
-            org.eclipse.ui.ide.IDE.getMarkerHelpRegistry();  // touch to ensure registry is initialized
-            org.eclipse.ui.IMarkerHelpRegistry registry = org.eclipse.ui.ide.IDE.getMarkerHelpRegistry();
-            if (registry.hasResolutions(marker))
-            {
-                for (org.eclipse.ui.IMarkerResolution r : registry.getResolutions(marker))
-                {
-                    String label = r.getLabel();
-                    String desc = (r instanceof org.eclipse.ui.IMarkerResolution2 r2) ? r2.getDescription() : null;
-                    fixes.add(new QuickFix(label, desc, m -> r.run(m)));
-                }
-            }
-        }
-        catch (Exception e)
-        {
-            // registry lookup is best-effort
-        }
-
-        // --- Mechanism 2: JDT JavaCorrectionProcessor (Java markers only, supplements registry) ---
         try
         {
             if (marker.getType().equals(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER)
                     && marker.getResource() instanceof IFile file)
             {
+                // Java marker: collect proposals directly from JavaCorrectionProcessor
                 ICompilationUnit cu = (ICompilationUnit) JavaCore.create(file);
                 if (cu != null && cu.exists())
                 {
@@ -822,34 +816,47 @@ public class CodeAnalysisService
                     int end     = marker.getAttribute(IMarker.CHAR_END, -1);
                     boolean isError = marker.getAttribute(IMarker.SEVERITY, 0) == IMarker.SEVERITY_ERROR;
                     String[] args = readMarkerArguments(marker);
-                    String markerType = marker.getType();
 
                     if (start >= 0 && end >= 0)
                     {
                         org.eclipse.jdt.internal.ui.text.correction.ProblemLocation location =
                             new org.eclipse.jdt.internal.ui.text.correction.ProblemLocation(
-                                start, end - start, id, args, isError, markerType);
+                                start, end - start, id, args, isError, marker.getType());
 
                         org.eclipse.jdt.internal.ui.text.correction.AssistContext context =
                             new org.eclipse.jdt.internal.ui.text.correction.AssistContext(cu, start, end - start);
 
-                        List<IJavaCompletionProposal> jdtProposals = new ArrayList<>();
+                        List<IJavaCompletionProposal> proposals = new ArrayList<>();
                         org.eclipse.jdt.internal.ui.text.correction.JavaCorrectionProcessor.collectCorrections(
-                            context, new org.eclipse.jdt.ui.text.java.IProblemLocation[]{ location }, jdtProposals);
+                            context, new org.eclipse.jdt.ui.text.java.IProblemLocation[]{ location }, proposals);
 
-                        jdtProposals.sort((a, b) -> Integer.compare(b.getRelevance(), a.getRelevance()));
+                        proposals.sort((a, b) -> Integer.compare(b.getRelevance(), a.getRelevance()));
 
-                        // Add JDT proposals that aren't already covered by the registry (dedupe by label)
-                        java.util.Set<String> existingLabels = new java.util.HashSet<>();
-                        fixes.forEach(f -> existingLabels.add(f.label()));
-
-                        for (IJavaCompletionProposal p : jdtProposals)
+                        for (IJavaCompletionProposal p : proposals)
                         {
                             String label = p.getDisplayString();
-                            if (existingLabels.add(label))  // true if newly added
+                            if (seenLabels.add(label))
                             {
-                                fixes.add(new QuickFix(label, null, m -> applyJdtProposal(p, m)));
+                                String desc = p.getAdditionalProposalInfo();
+                                    fixes.add(new QuickFix(label, desc, m -> applyJdtProposal(p, m)));
                             }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                // Non-Java marker: use the registry; run() works for PDE/m2e/build-path fixes
+                org.eclipse.ui.IMarkerHelpRegistry registry = org.eclipse.ui.ide.IDE.getMarkerHelpRegistry();
+                if (registry.hasResolutions(marker))
+                {
+                    for (org.eclipse.ui.IMarkerResolution r : registry.getResolutions(marker))
+                    {
+                        String label = r.getLabel();
+                        if (seenLabels.add(label))
+                        {
+                            String desc = (r instanceof org.eclipse.ui.IMarkerResolution2 r2) ? r2.getDescription() : null;
+                            fixes.add(new QuickFix(label, desc, m -> { r.run(m); }));
                         }
                     }
                 }
@@ -857,53 +864,113 @@ public class CodeAnalysisService
         }
         catch (Exception e)
         {
-            // JDT supplement is best-effort
+            // best-effort
         }
 
         return fixes;
     }
-
     /** Applies a JDT IJavaCompletionProposal headlessly. */
     private void applyJdtProposal(IJavaCompletionProposal proposal, IMarker marker)
     {
         try
         {
+            IFile file = (IFile) marker.getResource();
+
+            // For ICUCorrectionProposal: extract the TextEdit from the TextChange and apply
+            // it directly to a Document built from the current file bytes. This is the only
+            // path that works reliably in both live Eclipse and headless Tycho environments:
+            // - proposal.apply(IDocument) may be a no-op headlessly (needs active editor)
+            // - TextChange.perform() does not modify the document returned by getCurrentDocument()
             if (proposal instanceof org.eclipse.jdt.core.manipulation.ICUCorrectionProposal icp)
             {
-                icp.getTextChange().perform(new NullProgressMonitor());
+                org.eclipse.ltk.core.refactoring.TextChange change = icp.getTextChange();
+                String currentContent = new String(file.getContents(true).readAllBytes(),
+                        java.nio.charset.StandardCharsets.UTF_8);
+                org.eclipse.jface.text.Document doc = new org.eclipse.jface.text.Document(currentContent);
+                org.eclipse.text.edits.TextEdit edit = change.getEdit();
+                if (edit != null)
+                {
+                    edit.apply(doc);
+                }
+                String charset = file.getCharset();
+                byte[] bytes = doc.get().getBytes(java.nio.charset.Charset.forName(charset));
+                file.setContents(new java.io.ByteArrayInputStream(bytes), IResource.FORCE, new NullProgressMonitor());
+                return;
             }
-            else
+
+            // Fallback for non-ICU proposals: use TextFileDocumentProvider.
+            org.eclipse.ui.editors.text.TextFileDocumentProvider provider =
+                new org.eclipse.ui.editors.text.TextFileDocumentProvider();
+            provider.connect(file);
+            try
             {
-                // Fallback via TextFileDocumentProvider
-                IFile file = (IFile) marker.getResource();
-                org.eclipse.ui.editors.text.TextFileDocumentProvider provider =
-                    new org.eclipse.ui.editors.text.TextFileDocumentProvider();
-                provider.connect(file);
-                try
+                org.eclipse.jface.text.IDocument doc = provider.getDocument(file);
+                if (doc == null)
+                    throw new RuntimeException("Could not open document for " + file.getFullPath());
+                proposal.apply(doc);
+                String charset = file.getCharset();
+                byte[] bytes = doc.get().getBytes(java.nio.charset.Charset.forName(charset));
+                file.setContents(new java.io.ByteArrayInputStream(bytes), IResource.FORCE, new NullProgressMonitor());
+            }
+            finally
+            {
+                provider.disconnect(file);
+                // Explicitly disconnect the underlying ITextFileBuffer to release the OS file handle
+                // on Windows, where file handles are not released until the reference count reaches zero.
+                org.eclipse.core.filebuffers.ITextFileBufferManager mgr =
+                    org.eclipse.core.filebuffers.FileBuffers.getTextFileBufferManager();
+                org.eclipse.core.runtime.IPath loc = file.getFullPath();
+                org.eclipse.core.filebuffers.ITextFileBuffer buf =
+                    mgr.getTextFileBuffer(loc, org.eclipse.core.filebuffers.LocationKind.IFILE);
+                if (buf != null)
                 {
-                    org.eclipse.jface.text.IDocument doc = provider.getDocument(file);
-                    if (doc == null)
-                    {
-                        throw new RuntimeException("Could not open document for " + file.getFullPath());
-                    }
-                    proposal.apply(doc);
-                    provider.saveDocument(new NullProgressMonitor(), file, doc, true);
-                }
-                finally
-                {
-                    provider.disconnect(file);
+                    mgr.disconnect(loc, org.eclipse.core.filebuffers.LocationKind.IFILE, new NullProgressMonitor());
                 }
             }
-        }
-        catch (RuntimeException re)
-        {
-            throw re;
         }
         catch (Exception e)
         {
-            throw new RuntimeException(e);
+            throw new RuntimeException("applyJdtProposal failed: " + e.getMessage(), e);
         }
     }
+
+
+
+    /**
+     * Flushes the Eclipse ITextFileBuffer for the given IFile to disk.
+     * IMarkerResolution.run() modifies the file buffer but may not commit it in a headless
+     * (Tycho) environment. This ensures the changes reach disk.
+     * ICUCorrectionProposal already writes via IFile.setContents() inside applyJdtProposal(),
+     * so calling this afterward is harmless -- the buffer will be clean and isDirty() = false.
+     */
+    private void saveFileBuffer(IFile file)
+    {
+        try
+        {
+            org.eclipse.core.filebuffers.ITextFileBufferManager mgr =
+                org.eclipse.core.filebuffers.FileBuffers.getTextFileBufferManager();
+            org.eclipse.core.runtime.IPath location = file.getFullPath();
+            mgr.connect(location, org.eclipse.core.filebuffers.LocationKind.IFILE, new NullProgressMonitor());
+            try
+            {
+                org.eclipse.core.filebuffers.ITextFileBuffer buf =
+                    mgr.getTextFileBuffer(location, org.eclipse.core.filebuffers.LocationKind.IFILE);
+                if (buf != null && buf.isDirty())
+                {
+                    buf.commit(new NullProgressMonitor(), true);
+                }
+            }
+            finally
+            {
+                mgr.disconnect(location, org.eclipse.core.filebuffers.LocationKind.IFILE, new NullProgressMonitor());
+            }
+        }
+        catch (Exception e)
+        {
+            // best-effort: ICUCorrectionProposal already wrote directly via IFile.setContents()
+        }
+    }
+
 
     /** Reads the raw problem arguments from a marker. */
     private String[] readMarkerArguments(IMarker marker)
@@ -972,7 +1039,7 @@ public class CodeAnalysisService
             var result = new StringBuilder();
             result.append("# Import Suggestions for ").append(filePath).append("\n\n");
 
-            IJavaProject javaProject = JavaCore.create(project);
+            JavaCore.create(project);
             int suggestionCount = 0;
 
             for (IMarker marker : markers)

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/CodeAnalysisServiceTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/CodeAnalysisServiceTest.java
@@ -153,7 +153,16 @@ public class CodeAnalysisServiceTest {
         });
 
         if (project != null && project.exists()) {
-            project.delete(true, true, monitor);
+            // On Windows, file buffers may not release immediately. Retry a few times.
+            for (int attempt = 0; attempt < 5; attempt++) {
+                try {
+                    project.delete(true, true, monitor);
+                    break;
+                } catch (CoreException e) {
+                    if (attempt == 4) throw e;
+                    Thread.sleep(500);
+                }
+            }
         }
     }
     
@@ -297,7 +306,7 @@ public class CodeAnalysisServiceTest {
      * getCompilationErrors and reports success.
      */
     @Test
-    public void testExecuteQuickFix_AddImport() throws CoreException, InterruptedException {
+    public void testExecuteQuickFix_AddImport() throws CoreException, InterruptedException, java.io.IOException {
         String source =
                 "package com.example;\n\n" +
                 "public class FixMe {\n" +
@@ -322,17 +331,35 @@ public class CodeAnalysisServiceTest {
         System.out.println("getCompilationErrors before apply:\n" + errorsResult);
         assertTrue(errorsResult.contains("Marker ID:"), "Errors result must contain a Marker ID");
 
-        long markerId = extractFirstMarkerId(errorsResult);
+        // Find the marker whose index-0 fix is the import fix (JDT ICUCorrectionProposal marker)
+        long markerId = extractMarkerIdWithImportAtIndex0(errorsResult, "Import 'ArrayList'");
+        if (markerId == -1L)
+        {
+            // Fallback: use the first marker ID
+            markerId = extractFirstMarkerId(errorsResult);
+        }
         assertNotEquals(-1L, markerId, "Should have parsed a valid marker ID");
 
-        // Apply proposal 0 â typically "Import ArrayList (java.util)"
-        String applyResult = service.executeQuickFix(markerId, 0);
+        // Find the index of the import fix for this marker
+        int importIndex = extractImportFixIndex(errorsResult, markerId, "Import 'ArrayList'");
+        if (importIndex == -1) importIndex = 0;
+
+        String applyResult = service.executeQuickFix(markerId, importIndex);
         System.out.println("executeQuickFix result: " + applyResult);
 
-        // Either the fix was applied successfully, or we get an environment-specific error
-        // (e.g. no Display in headless); either way the call must not throw
+        // The call must not throw
         assertTrue(applyResult.contains("Quick fix applied") || applyResult.startsWith("Error"),
                 "Result should indicate applied fix or an error message");
+
+        // Verify the fix was actually persisted to disk by reading the file directly.
+        if (applyResult.contains("Quick fix applied"))
+        {
+            file.refreshLocal(IResource.DEPTH_ZERO, monitor);
+            String fileContent = new String(file.getContents(true).readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+            System.out.println("File content after fix:\\n" + fileContent);
+            assertTrue(fileContent.contains("import java.util.ArrayList"),
+                    "File on disk should contain the added import after fix is applied. File content: " + fileContent);
+        }
     }
 
     /**
@@ -446,4 +473,66 @@ public class CodeAnalysisServiceTest {
         
         return file;
     }
+
+    /**
+     * Finds the first marker ID in the errorsResult whose index-0 quick-fix proposal label
+     * contains the given fixLabelPrefix. Returns -1 if not found.
+     */
+    private long extractMarkerIdWithImportAtIndex0(String text, String fixLabelPrefix)
+    {
+        long currentMarkerId = -1L;
+        for (String line : text.split("\n"))
+        {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("- Marker ID:"))
+            {
+                try { currentMarkerId = Long.parseLong(trimmed.substring("- Marker ID:".length()).trim()); }
+                catch (NumberFormatException ignored) {}
+            }
+            else if (trimmed.startsWith("- [0]") && currentMarkerId != -1L)
+            {
+                if (trimmed.contains(fixLabelPrefix))
+                    return currentMarkerId;
+            }
+        }
+        return -1L;
+    }
+
+    /**
+     * For the given markerId block in errorsResult, finds the index of the first proposal
+     * whose label contains fixLabelPrefix. Returns -1 if not found.
+     */
+    private int extractImportFixIndex(String text, long markerId, String fixLabelPrefix)
+    {
+        boolean inBlock = false;
+        for (String line : text.split("\n"))
+        {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("- Marker ID:"))
+            {
+                try
+                {
+                    long id = Long.parseLong(trimmed.substring("- Marker ID:".length()).trim());
+                    inBlock = (id == markerId);
+                }
+                catch (NumberFormatException ignored) {}
+            }
+            else if (inBlock && trimmed.startsWith("- ["))
+            {
+                int bracket = trimmed.indexOf(']');
+                if (bracket > 2)
+                {
+                    try
+                    {
+                        int idx = Integer.parseInt(trimmed.substring(2, bracket));
+                        if (trimmed.contains(fixLabelPrefix))
+                            return idx;
+                    }
+                    catch (NumberFormatException ignored) {}
+                }
+            }
+        }
+        return -1;
+    }
+
 }

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/CodeAnalysisServiceTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/CodeAnalysisServiceTest.java
@@ -259,12 +259,11 @@ public class CodeAnalysisServiceTest {
     }
 
     /**
-     * Tests that getQuickFixes returns marker IDs and fix proposals for a file
-     * containing a missing-import error (use of ArrayList without import).
+     * Tests that getCompilationErrors includes Marker IDs and quick-fix proposals
+     * inline for a file containing a missing-import error.
      */
     @Test
-    public void testGetQuickFixes_MissingImport() throws CoreException, InterruptedException {
-        // Class that uses ArrayList without importing â JDT offers "Import ArrayList (java.util)"
+    public void testGetCompilationErrors_IncludesQuickFixes() throws CoreException, InterruptedException {
         String source =
                 "package com.example;\n\n" +
                 "public class MissingImportClass {\n" +
@@ -282,88 +281,20 @@ public class CodeAnalysisServiceTest {
 
         IMarker[] markers = project.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
         org.junit.jupiter.api.Assumptions.assumeTrue(markers.length > 0,
-                "No error markers generated â Java builder not active in this environment");
+                "No error markers generated - Java builder not active in this environment");
 
-        String result = service.getQuickFixes(TEST_PROJECT_NAME, "src/com/example/MissingImportClass.java", null);
-        System.out.println("getQuickFixes result:\n" + result);
+        String result = service.getCompilationErrors(TEST_PROJECT_NAME, "ALL", 50);
+        System.out.println("getCompilationErrors (with quick fixes) result:\n" + result);
 
-        assertTrue(result.contains("# Quick Fixes for"), "Should contain header");
         assertTrue(result.contains("Marker ID:"), "Should contain Marker ID");
-        // JDT should suggest importing ArrayList
+        assertTrue(result.contains("executeQuickFix"), "Should hint to call executeQuickFix");
         assertTrue(result.contains("ArrayList") || result.contains("Import"),
                 "Should contain import-related quick fix proposal");
     }
 
     /**
-     * Tests getQuickFixes with a line-number filter â only fixes for the given line
-     * should appear; fixes on other lines must be absent.
-     */
-    @Test
-    public void testGetQuickFixes_WithLineFilter() throws CoreException, InterruptedException {
-        // Two separate errors on different lines
-        String source =
-                "package com.example;\n\n" +
-                "public class TwoErrors {\n" +
-                "    public void test() {\n" +
-                "        ArrayList<String> list = new ArrayList<>();\n" +
-                "        HashMap<String,String> map = new HashMap<>();\n" +
-                "    }\n" +
-                "}\n";
-
-        createFile("src/com/example/TwoErrors.java", source);
-        project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
-        project.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
-        Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, monitor);
-        Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, monitor);
-        Thread.sleep(500);
-
-        IMarker[] markers = project.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
-        org.junit.jupiter.api.Assumptions.assumeTrue(markers.length > 0,
-                "No error markers generated â Java builder not active in this environment");
-
-        // Ask for fixes only on line 5 (ArrayList line)
-        String result = service.getQuickFixes(TEST_PROJECT_NAME, "src/com/example/TwoErrors.java", 5);
-        System.out.println("getQuickFixes (line 5) result:\n" + result);
-
-        // Should mention line 5 or ArrayList; must NOT mention line 6
-        assertTrue(result.contains("line 5") || result.contains("ArrayList") || result.contains("No problems found"),
-                "Should contain fix info for line 5 (or indicate no problems at that line)");
-        assertFalse(result.contains("line 6"), "Should NOT contain fixes for line 6");
-    }
-
-    /**
-     * Tests that getQuickFixes returns "No problems found" for a clean file.
-     */
-    @Test
-    public void testGetQuickFixes_NoErrors() throws CoreException, InterruptedException {
-        // A trivially valid class â no unused variables, no missing imports, no warnings.
-        String source =
-                "package com.example;\n\n" +
-                "public class CleanClass {\n" +
-                "    public String greet(String name) {\n" +
-                "        return \"Hello \" + name;\n" +
-                "    }\n" +
-                "}\n";
-
-        createFile("src/com/example/CleanClass.java", source);
-        project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
-        project.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
-        Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, monitor);
-        Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, monitor);
-        Thread.sleep(500);
-
-        String result = service.getQuickFixes(TEST_PROJECT_NAME, "src/com/example/CleanClass.java", null);
-        System.out.println("getQuickFixes (clean) result:\n" + result);
-
-        // A file with no errors or warnings should report "No problems found"
-        assertTrue(result.contains("No problems found"), "Should report no problems for clean file");
-        assertFalse(result.contains("## ERROR"), "CleanClass.java should have no ERROR markers");
-        assertFalse(result.contains("## WARNING"), "CleanClass.java should have no WARNING markers");
-    }
-
-    /**
-     * Tests that executeQuickFix applies the "add import" quick fix and reports
-     * success. Also verifies the error markers disappear after the fix.
+     * Tests that executeQuickFix applies the "add import" quick fix obtained via
+     * getCompilationErrors and reports success.
      */
     @Test
     public void testExecuteQuickFix_AddImport() throws CoreException, InterruptedException {
@@ -386,11 +317,12 @@ public class CodeAnalysisServiceTest {
         org.junit.jupiter.api.Assumptions.assumeTrue(markersBefore.length > 0,
                 "No error markers on FixMe.java â Java builder not active in this environment");
 
-        String quickFixResult = service.getQuickFixes(TEST_PROJECT_NAME, "src/com/example/FixMe.java", null);
-        System.out.println("Quick fixes before apply:\n" + quickFixResult);
-        assertTrue(quickFixResult.contains("Marker ID:"), "Quick fix result must contain a Marker ID");
+        // Obtain marker ID the same way an LLM would: via getCompilationErrors
+        String errorsResult = service.getCompilationErrors(TEST_PROJECT_NAME, "ALL", 50);
+        System.out.println("getCompilationErrors before apply:\n" + errorsResult);
+        assertTrue(errorsResult.contains("Marker ID:"), "Errors result must contain a Marker ID");
 
-        long markerId = extractFirstMarkerId(quickFixResult);
+        long markerId = extractFirstMarkerId(errorsResult);
         assertNotEquals(-1L, markerId, "Should have parsed a valid marker ID");
 
         // Apply proposal 0 â typically "Import ArrayList (java.util)"
@@ -420,6 +352,10 @@ public class CodeAnalysisServiceTest {
     private long extractFirstMarkerId(String text) {
         for (String line : text.split("\\n")) {
             line = line.trim();
+            // handle both "Marker ID: 123" and "- Marker ID: 123"
+            if (line.startsWith("- Marker ID:")) {
+                line = line.substring("- ".length()).trim();
+            }
             if (line.startsWith("Marker ID:")) {
                 try {
                     return Long.parseLong(line.substring("Marker ID:".length()).trim());

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/CodeAnalysisServiceTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/CodeAnalysisServiceTest.java
@@ -3,6 +3,7 @@ package com.github.gradusnikov.eclipse.plugin.assistai.mcp.services;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -25,6 +26,7 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.EclipseContextFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.launching.JavaRuntime;
@@ -62,15 +64,26 @@ public class CodeAnalysisServiceTest {
             project.delete(true, true, monitor);
         }
         
-        // Create a test project
+        // Create a test project â create plain (closed), then open, then add natures.
+        // Natures MUST be added via setDescription() on an already-open project so that
+        // JavaNature.configure() is invoked and registers javabuilder in the build spec.
         project = root.getProject(TEST_PROJECT_NAME);
         IProjectDescription desc = project.getWorkspace().newProjectDescription(project.getName());
-        desc.setNatureIds(new String[] {JavaCore.NATURE_ID}); // set Java nature
         project.create(desc, monitor);
         project.open(monitor);
+
+        // Add Java nature to the open project â triggers JavaNature.configure()
+        IProjectDescription openDesc = project.getDescription();
+        openDesc.setNatureIds(new String[] { JavaCore.NATURE_ID });
+        project.setDescription(openDesc, monitor);
         
         // Set up Java project
         javaProject = JavaCore.create(project);
+        
+        // Set Java 21 compliance so diamond operators, var, etc. all compile cleanly
+        javaProject.setOption(JavaCore.COMPILER_COMPLIANCE, "21");
+        javaProject.setOption(JavaCore.COMPILER_SOURCE, "21");
+        javaProject.setOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, "21");
         
         // Create output folder (bin)
         IFolder binFolder = project.getFolder("bin");
@@ -104,8 +117,10 @@ public class CodeAnalysisServiceTest {
         // Force a full build of the project
         project.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
         
-        // Wait a moment for the build to complete and for Eclipse to process markers
-        Thread.sleep(1000);
+        // Wait for all build and auto-build background jobs to complete
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, monitor);
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, monitor);
+        Thread.sleep(500);
         
         // Initialize service with DI context
         IEclipseContext context = EclipseContextFactory.create();
@@ -114,8 +129,29 @@ public class CodeAnalysisServiceTest {
     }
     
     @AfterEach
-    public void afterEach() throws CoreException {
-        // Clean up the test project
+    public void afterEach() throws CoreException, InterruptedException {
+        // Wait for all background build/index jobs to finish before deleting the
+        // project â otherwise JDT still holds file handles and Eclipse shows a
+        // "resource already deleted" dialog.
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, monitor);
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, monitor);
+        // Give JDT indexer and other post-build jobs a moment to settle
+        Thread.sleep(500);
+
+        // Close any editors opened by executeQuickFix (which opens a document to
+        // apply the text change). If the editor is still open when the project is
+        // deleted, Eclipse shows a "File Not Accessible" dialog.
+        org.eclipse.ui.PlatformUI.getWorkbench().getDisplay().syncExec(() -> {
+            org.eclipse.ui.IWorkbenchWindow window =
+                    org.eclipse.ui.PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+            if (window != null) {
+                org.eclipse.ui.IWorkbenchPage page = window.getActivePage();
+                if (page != null) {
+                    page.closeAllEditors(false); // false = don't save
+                }
+            }
+        });
+
         if (project != null && project.exists()) {
             project.delete(true, true, monitor);
         }
@@ -157,9 +193,9 @@ public class CodeAnalysisServiceTest {
         
         // Force a build to generate error markers
         project.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
-        
-        // Wait for build and marker generation
-        Thread.sleep(1000);
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, monitor);
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, monitor);
+        Thread.sleep(500);
         
         // Verify markers were created
         IMarker[] markers = project.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
@@ -194,9 +230,9 @@ public class CodeAnalysisServiceTest {
         
         // Force a build to generate markers
         project.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
-        
-        // Wait for build and marker generation
-        Thread.sleep(1000);
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, monitor);
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, monitor);
+        Thread.sleep(500);
         
         // Test getting only ERROR severity problems
         String errorResult = service.getCompilationErrors(
@@ -220,6 +256,178 @@ public class CodeAnalysisServiceTest {
         // Verify warning result contains warnings or indicates no warnings found
         // This is more environment-dependent as some JDKs might not generate warnings for our example
         assertTrue(warningResult.contains("WARNING") || warningResult.contains("No compilation problems found"));
+    }
+
+    /**
+     * Tests that getQuickFixes returns marker IDs and fix proposals for a file
+     * containing a missing-import error (use of ArrayList without import).
+     */
+    @Test
+    public void testGetQuickFixes_MissingImport() throws CoreException, InterruptedException {
+        // Class that uses ArrayList without importing â JDT offers "Import ArrayList (java.util)"
+        String source =
+                "package com.example;\n\n" +
+                "public class MissingImportClass {\n" +
+                "    public void test() {\n" +
+                "        ArrayList<String> list = new ArrayList<>();\n" +
+                "    }\n" +
+                "}\n";
+
+        createFile("src/com/example/MissingImportClass.java", source);
+        project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+        project.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, monitor);
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, monitor);
+        Thread.sleep(500);
+
+        IMarker[] markers = project.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
+        org.junit.jupiter.api.Assumptions.assumeTrue(markers.length > 0,
+                "No error markers generated â Java builder not active in this environment");
+
+        String result = service.getQuickFixes(TEST_PROJECT_NAME, "src/com/example/MissingImportClass.java", null);
+        System.out.println("getQuickFixes result:\n" + result);
+
+        assertTrue(result.contains("# Quick Fixes for"), "Should contain header");
+        assertTrue(result.contains("Marker ID:"), "Should contain Marker ID");
+        // JDT should suggest importing ArrayList
+        assertTrue(result.contains("ArrayList") || result.contains("Import"),
+                "Should contain import-related quick fix proposal");
+    }
+
+    /**
+     * Tests getQuickFixes with a line-number filter â only fixes for the given line
+     * should appear; fixes on other lines must be absent.
+     */
+    @Test
+    public void testGetQuickFixes_WithLineFilter() throws CoreException, InterruptedException {
+        // Two separate errors on different lines
+        String source =
+                "package com.example;\n\n" +
+                "public class TwoErrors {\n" +
+                "    public void test() {\n" +
+                "        ArrayList<String> list = new ArrayList<>();\n" +
+                "        HashMap<String,String> map = new HashMap<>();\n" +
+                "    }\n" +
+                "}\n";
+
+        createFile("src/com/example/TwoErrors.java", source);
+        project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+        project.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, monitor);
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, monitor);
+        Thread.sleep(500);
+
+        IMarker[] markers = project.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
+        org.junit.jupiter.api.Assumptions.assumeTrue(markers.length > 0,
+                "No error markers generated â Java builder not active in this environment");
+
+        // Ask for fixes only on line 5 (ArrayList line)
+        String result = service.getQuickFixes(TEST_PROJECT_NAME, "src/com/example/TwoErrors.java", 5);
+        System.out.println("getQuickFixes (line 5) result:\n" + result);
+
+        // Should mention line 5 or ArrayList; must NOT mention line 6
+        assertTrue(result.contains("line 5") || result.contains("ArrayList") || result.contains("No problems found"),
+                "Should contain fix info for line 5 (or indicate no problems at that line)");
+        assertFalse(result.contains("line 6"), "Should NOT contain fixes for line 6");
+    }
+
+    /**
+     * Tests that getQuickFixes returns "No problems found" for a clean file.
+     */
+    @Test
+    public void testGetQuickFixes_NoErrors() throws CoreException, InterruptedException {
+        // A trivially valid class â no unused variables, no missing imports, no warnings.
+        String source =
+                "package com.example;\n\n" +
+                "public class CleanClass {\n" +
+                "    public String greet(String name) {\n" +
+                "        return \"Hello \" + name;\n" +
+                "    }\n" +
+                "}\n";
+
+        createFile("src/com/example/CleanClass.java", source);
+        project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+        project.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, monitor);
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, monitor);
+        Thread.sleep(500);
+
+        String result = service.getQuickFixes(TEST_PROJECT_NAME, "src/com/example/CleanClass.java", null);
+        System.out.println("getQuickFixes (clean) result:\n" + result);
+
+        // A file with no errors or warnings should report "No problems found"
+        assertTrue(result.contains("No problems found"), "Should report no problems for clean file");
+        assertFalse(result.contains("## ERROR"), "CleanClass.java should have no ERROR markers");
+        assertFalse(result.contains("## WARNING"), "CleanClass.java should have no WARNING markers");
+    }
+
+    /**
+     * Tests that executeQuickFix applies the "add import" quick fix and reports
+     * success. Also verifies the error markers disappear after the fix.
+     */
+    @Test
+    public void testExecuteQuickFix_AddImport() throws CoreException, InterruptedException {
+        String source =
+                "package com.example;\n\n" +
+                "public class FixMe {\n" +
+                "    public void test() {\n" +
+                "        ArrayList<String> list = new ArrayList<>();\n" +
+                "    }\n" +
+                "}\n";
+
+        IFile file = createFile("src/com/example/FixMe.java", source);
+        project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+        project.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, monitor);
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, monitor);
+        Thread.sleep(500);
+
+        IMarker[] markersBefore = file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO);
+        org.junit.jupiter.api.Assumptions.assumeTrue(markersBefore.length > 0,
+                "No error markers on FixMe.java â Java builder not active in this environment");
+
+        String quickFixResult = service.getQuickFixes(TEST_PROJECT_NAME, "src/com/example/FixMe.java", null);
+        System.out.println("Quick fixes before apply:\n" + quickFixResult);
+        assertTrue(quickFixResult.contains("Marker ID:"), "Quick fix result must contain a Marker ID");
+
+        long markerId = extractFirstMarkerId(quickFixResult);
+        assertNotEquals(-1L, markerId, "Should have parsed a valid marker ID");
+
+        // Apply proposal 0 â typically "Import ArrayList (java.util)"
+        String applyResult = service.executeQuickFix(markerId, 0);
+        System.out.println("executeQuickFix result: " + applyResult);
+
+        // Either the fix was applied successfully, or we get an environment-specific error
+        // (e.g. no Display in headless); either way the call must not throw
+        assertTrue(applyResult.contains("Quick fix applied") || applyResult.startsWith("Error"),
+                "Result should indicate applied fix or an error message");
+    }
+
+    /**
+     * Tests that executeQuickFix returns an error message for an unknown marker ID.
+     */
+    @Test
+    public void testExecuteQuickFix_UnknownMarkerId() {
+        String result = service.executeQuickFix(Long.MAX_VALUE, 0);
+        System.out.println("executeQuickFix (bad id) result: " + result);
+        assertTrue(result.startsWith("Error:"), "Should return an error for unknown marker ID");
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private long extractFirstMarkerId(String text) {
+        for (String line : text.split("\\n")) {
+            line = line.trim();
+            if (line.startsWith("Marker ID:")) {
+                try {
+                    return Long.parseLong(line.substring("Marker ID:".length()).trim());
+                } catch (NumberFormatException ignored) {
+                }
+            }
+        }
+        return -1L;
     }
     
     private void createPackageStructure() throws CoreException {


### PR DESCRIPTION
we had a getQuickFixes() but i didn't see what you can then really do with it and why the AI/LLM would be calling it.

But a quick fix belongs to a Error or Warning marker, so what this pull does it that getCompilationErrors() now also returns a list of quick fixes with a comment that you can then quick fix it by passing the index of the quick fix you want to the new tool: executeQuickFix

this does remove the getQuickFixes() because i don't think that would be used a lot (except if you would really tell i explicitly? but now it always just gets possible quickfixes through the compile errors get anyway)

Now an instruction could be that "clean up the code base by getting all warnings and errors of a project and if it can be quick fixed try that first)