### PR TITLE
fix: correct CONTAINER attribute in JUnit test launcher to use getHandleIdentifier()

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/UnitTestService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/UnitTestService.java
@@ -463,9 +463,14 @@ public class UnitTestService {
                         javaProject.getElementName());
                 
                 // Set the test target
+                // CONTAINER must use the Java element handle identifier (e.g. "=ProjectName"),
+                // NOT the IResource path (e.g. "/ProjectName") â the JUnit launcher resolves
+                // the input element via JavaCore.create(handleId), and a resource path causes
+                // "The input element of the launch configuration does not exist".
                 if (testClass != null) {
                     workingCopy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, 
                             testClass.getFullyQualifiedName());
+                    workingCopy.setAttribute("org.eclipse.jdt.junit.CONTAINER", "");
                     
                     if (methodName != null && !methodName.isEmpty()) {
                         workingCopy.setAttribute("org.eclipse.jdt.junit.TEST_METHOD", methodName);
@@ -473,11 +478,11 @@ public class UnitTestService {
                 } else if (packageFragment != null) {
                     workingCopy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, "");
                     workingCopy.setAttribute("org.eclipse.jdt.junit.CONTAINER", 
-                            packageFragment.getPath().toString());
+                            packageFragment.getHandleIdentifier());
                 } else {
                     workingCopy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, "");
                     workingCopy.setAttribute("org.eclipse.jdt.junit.CONTAINER", 
-                            javaProject.getPath().toString());
+                            javaProject.getHandleIdentifier());
                 }
                 
                 // Detect the appropriate JUnit version from the project's classpath


### PR DESCRIPTION
Using getPath().toString() on an IJavaElement produced a path that PDE could not resolve, causing 'The input element of the launch configuration does not exist'. Switching to getHandleIdentifier() returns the stable JDT handle string that the PDE JUnit launcher expects. Also explicitly clears CONTAINER when launching a single class so the two attributes don't conflict.