### PR TITLE
Clean up warnings: remove unused imports, fields, methods, and suppress restriction/deprecation warnings

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/commands/ProjectPreferencesCommand.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/commands/ProjectPreferencesCommand.java
@@ -12,7 +12,6 @@ import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.runtime.CoreException;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/completion/GhostTextManager.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/completion/GhostTextManager.java
@@ -33,8 +33,6 @@ import com.github.gradusnikov.eclipse.assistai.tools.UISynchronizeCallable;
 public class GhostTextManager
 {
 
-    private final ITextViewer textViewer;
-
     private final StyledText  styledText;
     
     private final UISynchronizeCallable uiSync;
@@ -49,8 +47,6 @@ public class GhostTextManager
     
     // Track which line has vertical indent applied
     private int               indentedLineIndex = -1;
-    private int               appliedIndent = 0;
-
     // Listeners
     private KeyListener       keyListener;
 
@@ -70,7 +66,6 @@ public class GhostTextManager
 
     public GhostTextManager( ITextViewer textViewer, UISynchronizeCallable uiSync )
     {
-        this.textViewer = textViewer;
         this.styledText = textViewer.getTextWidget();
         this.uiSync = uiSync;
         this.isShowing = false;
@@ -372,7 +367,6 @@ public class GhostTextManager
                 int indent = extraLines * lineHeight;
                 styledText.setLineVerticalIndent(nextLine, indent);
                 indentedLineIndex = nextLine;
-                appliedIndent = indent;
             }
         }
         catch (Exception e)
@@ -400,7 +394,6 @@ public class GhostTextManager
                 // Ignore
             }
             indentedLineIndex = -1;
-            appliedIndent = 0;
         }
     }
 
@@ -521,13 +514,10 @@ public class GhostTextManager
                         int lineStartOffset = st.getOffsetAtLine( ghostLine );
                         String currentLineText = st.getLine( ghostLine );
                         
-                        // Calculate indent (spaces/tabs at beginning)
-                        int indentChars = 0;
                         for ( char c : currentLineText.toCharArray() )
                         {
                             if ( c == ' ' || c == '\t' )
                             {
-                                indentChars++;
                             }
                             else
                             {

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/local/InMemoryTransport.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/local/InMemoryTransport.java
@@ -221,7 +221,6 @@ public class InMemoryTransport
         private final McpJsonMapper jsonMapper;
         private final BlockingQueue<McpSchema.JSONRPCMessage> inboundQueue;
         private final BlockingQueue<McpSchema.JSONRPCMessage> outboundQueue;
-        private final Sinks.Many<String> errorSink;
         private final ILog logger;
         private McpServerSession session;
         private final AtomicBoolean isClosing = new AtomicBoolean(false);
@@ -242,7 +241,6 @@ public class InMemoryTransport
             this.jsonMapper = jsonMapper;
             this.inboundQueue = inboundQueue;
             this.outboundQueue = outboundQueue;
-            this.errorSink = errorSink;
             this.logger = logger;
         }
 

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/DuckDuckSearchMcpServer.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/DuckDuckSearchMcpServer.java
@@ -27,7 +27,8 @@ public class DuckDuckSearchMcpServer
     @Inject
     ILog logger;
 
-    @Tool(name="webSearch", description="Performs a search using a Duck Duck Go search engine and returns the search result json.", type="object")
+    @SuppressWarnings("deprecation")
+	@Tool(name="webSearch", description="Performs a search using a Duck Duck Go search engine and returns the search result json.", type="object")
     public String webSearch(
             @ToolParam(name="query", description="A search query", required=true) String query)
     {

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeAnalysisService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeAnalysisService.java
@@ -61,7 +61,8 @@ public class CodeAnalysisService
      * @param maxDepth Maximum depth of the call hierarchy to retrieve
      * @return A formatted string containing the call hierarchy
      */
-    public String getMethodCallHierarchy(String fullyQualifiedClassName, 
+    @SuppressWarnings("restriction")
+	public String getMethodCallHierarchy(String fullyQualifiedClassName, 
                                   String methodName, 
                                   String methodSignature, 
                                   Integer maxDepth)
@@ -389,7 +390,8 @@ public class CodeAnalysisService
         }
     }    
     
-    private void collectCallHierarchy(MethodWrapper[] callers, int level, int maxDepth, StringBuilder result) {
+    @SuppressWarnings("restriction")
+	private void collectCallHierarchy(MethodWrapper[] callers, int level, int maxDepth, StringBuilder result) {
        
         if (level >= maxDepth) 
         {
@@ -447,7 +449,8 @@ public class CodeAnalysisService
         }
     }
     
-    private void collectCalleeHierarchy(MethodWrapper[] callees, int level, int maxDepth, StringBuilder result) {
+    @SuppressWarnings("restriction")
+	private void collectCalleeHierarchy(MethodWrapper[] callees, int level, int maxDepth, StringBuilder result) {
         if (level >= maxDepth) 
         {
             return;
@@ -797,7 +800,8 @@ public class CodeAnalysisService
      *
      * Non-Java markers (PDE, m2e, build-path, etc.): uses IMarkerHelpRegistry and run().
      */
-    private List<QuickFix> collectQuickFixes(IMarker marker)
+    @SuppressWarnings("restriction")
+	private List<QuickFix> collectQuickFixes(IMarker marker)
     {
         List<QuickFix> fixes = new ArrayList<>();
         java.util.Set<String> seenLabels = new java.util.HashSet<>();

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeEditingService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeEditingService.java
@@ -2554,7 +2554,6 @@ public class CodeEditingService
     {
         int originalStart; // 1-based line number in original file
         int originalCount; // number of lines from original
-        List<String> contextAndRemoveLines = new java.util.ArrayList<>(); // context (' ') and remove ('-') lines
         List<String> hunkLines = new java.util.ArrayList<>(); // all lines in the hunk with their prefixes
     }
 

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/GitService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/GitService.java
@@ -159,7 +159,8 @@ public class GitService
         }
     }
 
-    public String getLog(String projectName, int maxCount)
+    @SuppressWarnings("deprecation")
+	public String getLog(String projectName, int maxCount)
     {
         Repository repository = getRepository(projectName);
         try (Git git = new Git(repository))
@@ -375,7 +376,7 @@ public class GitService
         Repository repository = getRepository(projectName);
         try (Git git = new Git(repository))
         {
-            var result = git.stashApply().call();
+            git.stashApply().call();
             git.stashDrop().call();
             refreshProject(projectName);
             return "Applied and dropped stash.";

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/JavaLaunchService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/JavaLaunchService.java
@@ -1,8 +1,6 @@
 package com.github.gradusnikov.eclipse.assistai.mcp.services;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
@@ -33,7 +31,6 @@ import org.eclipse.e4.ui.di.UISynchronize;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.debug.core.IJavaBreakpoint;
 import org.eclipse.jdt.debug.core.IJavaLineBreakpoint;
 import org.eclipse.jdt.debug.core.JDIDebugModel;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
@@ -148,8 +145,6 @@ public class JavaLaunchService
             // Capture output
             var outputBuffer = new StringBuilder();
             var errorBuffer = new StringBuilder();
-            var latch = new CountDownLatch(1);
-
             // Launch
             final ILaunch[] launchHolder = new ILaunch[1];
             sync.syncExec(() ->
@@ -771,7 +766,6 @@ public class JavaLaunchService
                     {
                         if (thread.isSuspended() && thread instanceof org.eclipse.jdt.debug.core.IJavaThread)
                         {
-                            var javaThread = (org.eclipse.jdt.debug.core.IJavaThread) thread;
                             IStackFrame[] frames = thread.getStackFrames();
                             if (frames.length > 0 && frames[0] instanceof org.eclipse.jdt.debug.core.IJavaStackFrame)
                             {

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/MarkdownService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/MarkdownService.java
@@ -11,20 +11,14 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.e4.core.di.annotations.Creatable;
 
 import com.github.gradusnikov.eclipse.assistai.tools.ResourceUtilities;
 
-import jakarta.inject.Inject;
-
 @Creatable
 public class MarkdownService
 {
-    @Inject
-    private ILog logger;
-
     private static final Pattern ATX_HEADING = Pattern.compile("^(#{1,6})\\s+(.+?)\\s*#*\\s*$");
     private static final Pattern SETEXT_H1 = Pattern.compile("^={3,}\\s*$");
     private static final Pattern SETEXT_H2 = Pattern.compile("^-{3,}\\s*$");

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/ProjectService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/ProjectService.java
@@ -277,18 +277,6 @@ public class ProjectService {
         }
     }
     
-    /**
-     * Collects resources in a hierarchical structure for display.
-     * 
-     * @param resource The starting resource
-     * @param depth The current depth in the hierarchy
-     * @param result The StringBuilder to append results to
-     * @throws CoreException if an error occurs
-     */
-    private void collectResourcesForLLM(IResource resource, int depth, StringBuilder result) throws CoreException {
-        collectResourcesForLLM(resource, depth, Integer.MAX_VALUE, result);
-    }
-
     private void collectResourcesForLLM(IResource resource, int depth, int maxDepth, StringBuilder result) throws CoreException {
         if (aiIgnoreService.isExcluded(resource))
         {

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/UnitTestService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/UnitTestService.java
@@ -288,9 +288,6 @@ public class UnitTestService {
                 throw new RuntimeException("Error: Method '" + methodName + "' not found in class '" + className + "'.");
             }
             
-            // Create a test name with the specific method
-            String testName = className + "." + methodName;
-            
             // Run the tests
             return launchJUnitTests(javaProject, null, type, timeout, methodName);
             

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/AnthropicStreamJavaHttpClient.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/AnthropicStreamJavaHttpClient.java
@@ -9,7 +9,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -419,9 +418,6 @@ public class AnthropicStreamJavaHttpClient extends AbstractLanguageModelClient
 	                                        JsonNode toolUseNode = node.get("content_block");
 	                                        String toolName = toolUseNode.get("name").asText();
 	                                        String toolId = toolUseNode.get("id").asText();
-	                                        
-	                                        JsonNode inputNode = toolUseNode.get("input");
-	                                        String arguments = inputNode.toString();
 	                                        
 	                                        publisher.submit(new Incoming(Incoming.Type.FUNCTION_CALL, 
 	                                                String.format("\"function_call\" : { \n \"name\": \"%s\",\n \"id\": \"%s\",\n \"arguments\" :", toolName, toolId)));

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/ChatLanguageModelHttpClientProvider.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/ChatLanguageModelHttpClientProvider.java
@@ -1,19 +1,16 @@
 package com.github.gradusnikov.eclipse.assistai.network.clients;
 
 
-import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.e4.core.di.annotations.Creatable;
 
 import com.github.gradusnikov.eclipse.assistai.chat.ConversationContext;
-import com.github.gradusnikov.eclipse.assistai.mcp.local.InMemoryMcpClientRetistry;
 import com.github.gradusnikov.eclipse.assistai.models.ModelApiDescriptorRepository;
 import com.github.gradusnikov.eclipse.assistai.network.subscribers.AppendMessageToViewSubscriber;
 import com.github.gradusnikov.eclipse.assistai.network.subscribers.FunctionCallSubscriber;
 import com.github.gradusnikov.eclipse.assistai.network.subscribers.PrintMessageSubscriber;
 
-import io.modelcontextprotocol.client.McpSyncClient;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/DeepSeekStreamJavaHttpClient.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/DeepSeekStreamJavaHttpClient.java
@@ -9,7 +9,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/GeminiStreamJavaHttpClient.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/GeminiStreamJavaHttpClient.java
@@ -5,7 +5,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/GrokStreamJavaHttpClient.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/GrokStreamJavaHttpClient.java
@@ -10,7 +10,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/OpenAIResponsesJavaHttpClient.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/OpenAIResponsesJavaHttpClient.java
@@ -6,7 +6,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/OpenAIStreamJavaHttpClient.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/OpenAIStreamJavaHttpClient.java
@@ -8,7 +8,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/subscribers/AppendMessageToViewSubscriber.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/subscribers/AppendMessageToViewSubscriber.java
@@ -11,7 +11,6 @@ import org.eclipse.core.runtime.ILog;
 import org.eclipse.e4.core.di.annotations.Creatable;
 
 import com.github.gradusnikov.eclipse.assistai.chat.ChatMessage;
-import com.github.gradusnikov.eclipse.assistai.chat.Conversation;
 import com.github.gradusnikov.eclipse.assistai.chat.Incoming;
 import com.github.gradusnikov.eclipse.assistai.chat.Incoming.Type;
 import com.github.gradusnikov.eclipse.assistai.view.ChatViewPresenter;

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/subscribers/PrintMessageSubscriber.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/subscribers/PrintMessageSubscriber.java
@@ -7,8 +7,6 @@ import org.eclipse.e4.core.di.annotations.Creatable;
 
 import com.github.gradusnikov.eclipse.assistai.chat.Incoming;
 
-import jakarta.inject.Singleton;
-
 @Creatable
 //@Singleton
 public class PrintMessageSubscriber implements Flow.Subscriber<Incoming>

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/preferences/mcp/McpServerPreferencePage.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/preferences/mcp/McpServerPreferencePage.java
@@ -355,34 +355,6 @@ public class McpServerPreferencePage extends PreferencePage implements IWorkbenc
         removeEnvButton.setLayoutData( new GridData( SWT.FILL, SWT.CENTER, true, false ) );
     }
 
-    private Text addTextField( Composite form, String labelText )
-    {
-        Label label = new Label( form, SWT.NONE );
-        label.setText( labelText );
-        FormData labelData = new FormData();
-        Control[] children = form.getChildren();
-        if ( children.length == 0 )
-        {
-            // First control, attach to top
-            labelData.top = new FormAttachment( 0, 10 );
-        }
-        else
-        {
-            // Attach below the last control
-            labelData.top = new FormAttachment( children[children.length - 1], 10 );
-        }
-        labelData.left = new FormAttachment( 0, 10 );
-        label.setLayoutData( labelData );
-
-        Text text = new Text( form, SWT.BORDER );
-        FormData textData = new FormData();
-        textData.left = new FormAttachment( 0, 150 );
-        textData.right = new FormAttachment( 100, -10 );
-        textData.top = new FormAttachment( label, 0, SWT.CENTER );
-        text.setLayoutData( textData );
-        return text;
-    }
-
     private void initializeDetailsListeners()
     {
         // Tool checkbox listener

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/preferences/models/ModelPreferencePage.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/preferences/models/ModelPreferencePage.java
@@ -15,7 +15,6 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
-import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/prompt/PromptLoader.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/prompt/PromptLoader.java
@@ -29,7 +29,8 @@ public class PromptLoader
 
 	
 
-    public String getDefaultPrompt( String resourceFile )
+    @SuppressWarnings("deprecation")
+	public String getDefaultPrompt( String resourceFile )
     {
         try (var in = FileLocator.toFileURL( new URL( new URL(baseURL), resourceFile )  ).openStream();
              var dis = new DataInputStream(in);)

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/tools/AssistaiSharedFonts.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/tools/AssistaiSharedFonts.java
@@ -7,7 +7,6 @@ import java.util.Base64;
 import java.util.stream.Collectors;
 
 import org.apache.fontbox.ttf.TTFParser;
-import org.eclipse.core.runtime.ILog;
 import org.eclipse.e4.core.di.annotations.Creatable;
 
 import com.google.common.io.Files;
@@ -17,9 +16,6 @@ import jakarta.inject.Inject;
 @Creatable
 public class AssistaiSharedFonts
 {
-    @Inject
-    private ILog logger;
-    
     @Inject
     private AssistaiSharedFiles sharedFiles;
     

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/tools/ContentTypeDetector.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/tools/ContentTypeDetector.java
@@ -3,8 +3,6 @@ package com.github.gradusnikov.eclipse.assistai.tools;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
-import java.nio.file.Files;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.tika.Tika;
 import org.apache.tika.parser.txt.CharsetDetector;

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/view/ChatView.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/view/ChatView.java
@@ -22,8 +22,6 @@ import org.eclipse.jface.fieldassist.ContentProposalAdapter;
 import org.eclipse.jface.fieldassist.IContentProposal;
 import org.eclipse.jface.fieldassist.IContentProposalProvider;
 import org.eclipse.jface.fieldassist.TextContentAdapter;
-import org.eclipse.jface.resource.JFaceResources;
-import org.eclipse.jface.resource.LocalResourceManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.browser.BrowserFunction;
@@ -100,7 +98,8 @@ public class ChatView
     @Inject
     private AssistaiSharedFonts sharedFonts;
 
-    @Inject
+    @SuppressWarnings("restriction")
+	@Inject
     @Optional
     private IThemeEngine themeEngine;
 
@@ -721,7 +720,8 @@ public class ChatView
         return cssContent;
     }
 
-    private boolean isDarkTheme()
+    @SuppressWarnings("restriction")
+	private boolean isDarkTheme()
     {
         if ( themeEngine != null && themeEngine.getActiveTheme() != null )
         {

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/view/ResourcesView.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/view/ResourcesView.java
@@ -12,7 +12,6 @@ import org.eclipse.jface.viewers.StyledString;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.ViewerCell;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/view/dnd/handlers/TextTransferHandler.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/view/dnd/handlers/TextTransferHandler.java
@@ -1,6 +1,5 @@
 package com.github.gradusnikov.eclipse.assistai.view.dnd.handlers;
 
-import org.eclipse.core.runtime.ILog;
 import org.eclipse.e4.core.di.annotations.Creatable;
 import org.eclipse.swt.dnd.TextTransfer;
 import org.eclipse.swt.dnd.Transfer;
@@ -20,9 +19,6 @@ public class TextTransferHandler implements ITransferHandler
     
     @Inject
     private ResourceCacheHelper resourceCacheHelper;
-
-    @Inject
-    private ILog logger;
 
     @Override
     public Transfer getTransferType()

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/chat/ConversationContextTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/chat/ConversationContextTest.java
@@ -2,7 +2,6 @@ package com.github.gradusnikov.eclipse.assistai.chat;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -10,7 +9,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 
 /**

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/prompt/ChatMessageFactoryTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/prompt/ChatMessageFactoryTest.java
@@ -2,13 +2,9 @@ package com.github.gradusnikov.eclipse.assistai.prompt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Optional;
-import java.util.concurrent.Callable;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -28,7 +24,6 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.activities.WorkbenchActivityHelper;
 import org.eclipse.ui.ide.IDE;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,12 +34,7 @@ import org.osgi.util.tracker.ServiceTracker;
 
 import com.github.gradusnikov.eclipse.assistai.Activator;
 import com.github.gradusnikov.eclipse.assistai.chat.ChatMessage;
-import com.github.gradusnikov.eclipse.assistai.mcp.services.CodeAnalysisService;
-import com.github.gradusnikov.eclipse.assistai.mcp.services.CodeEditingService;
-import com.github.gradusnikov.eclipse.assistai.mcp.services.ConsoleService;
 import com.github.gradusnikov.eclipse.assistai.mcp.services.EditorService;
-import com.github.gradusnikov.eclipse.assistai.mcp.services.GitService;
-import com.github.gradusnikov.eclipse.assistai.tools.UISynchronizeCallable;
 
 public class ChatMessageFactoryTest {
 

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/main/HtmlToMarkdownConverterTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/main/HtmlToMarkdownConverterTest.java
@@ -1,7 +1,6 @@
 package com.github.gradusnikov.eclipse.plugin.assistai.main;
 
 
-import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/servers/TimeMcpServerTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/servers/TimeMcpServerTest.java
@@ -15,7 +15,6 @@ import com.github.gradusnikov.eclipse.assistai.mcp.servers.TimeMcpServer;
 public class TimeMcpServerTest {
 
     private TimeMcpServer timeMcpServer;
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final DateTimeFormatter OUTPUT_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z");
 
     @BeforeEach

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/CodeAnalysisServiceTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/CodeAnalysisServiceTest.java
@@ -1,7 +1,6 @@
 
 package com.github.gradusnikov.eclipse.plugin.assistai.mcp.services;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -20,7 +19,6 @@ import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILog;
-import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/transport/BearerTokenAuthenticationFilter.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/transport/BearerTokenAuthenticationFilter.java
@@ -2,10 +2,6 @@ package com.github.gradusnikov.eclipse.plugin.assistai.mcp.transport;
 
 import java.io.IOException;
 
-import org.eclipse.e4.core.di.annotations.Creatable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/transport/SdkHttpStreamingTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/transport/SdkHttpStreamingTest.java
@@ -348,53 +348,6 @@ public class SdkHttpStreamingTest
         }
     }
     
-    /**
-     * Creates an SSL context using the test truststore.
-     * This properly validates certificates signed by our test CA.
-     */
-    private static javax.net.ssl.SSLContext createSSLContextWithTruststore() throws Exception
-    {
-        // Load the truststore from classpath
-        try (InputStream truststoreStream = SdkHttpStreamingTest.class
-                .getResourceAsStream("/test/resources/ssl/test-truststore.jks")) {
-            
-            if (truststoreStream == null) {
-                throw new IOException("Truststore not found in classpath: /test/resources/ssl/test-truststore.jks");
-            }
-            
-            // Load truststore
-            java.security.KeyStore truststore = java.security.KeyStore.getInstance("JKS");
-            truststore.load(truststoreStream, "changeit".toCharArray());
-            
-            // Create TrustManagerFactory
-            javax.net.ssl.TrustManagerFactory tmf = 
-                javax.net.ssl.TrustManagerFactory.getInstance(
-                    javax.net.ssl.TrustManagerFactory.getDefaultAlgorithm());
-            tmf.init(truststore);
-            
-            // Create SSLContext
-            javax.net.ssl.SSLContext sslContext = javax.net.ssl.SSLContext.getInstance("TLS");
-            sslContext.init(null, tmf.getTrustManagers(), new java.security.SecureRandom());
-            
-            return sslContext;
-        }
-    }
-    
-    /**
-     * Creates an HttpClient configured with our test truststore.
-     */
-    private static java.net.http.HttpClient createHttpClientWithTruststore() throws Exception
-    {
-        if (!USE_HTTPS) {
-            // If not using HTTPS, return default client
-            return java.net.http.HttpClient.newHttpClient();
-        }
-        
-        return java.net.http.HttpClient.newBuilder()
-                .sslContext(createSSLContextWithTruststore())
-                .build();
-    }
-    
     private static Tomcat createTomcatServer(String contextPath, int port, Servlet servlet, boolean useAuth, boolean useHttps)
     {
         var tomcat = new Tomcat();


### PR DESCRIPTION
Fixed (with the new quick fix tool) almost all the warnings that where quickfixable, this cleans up the code quite a bit.