### PR TITLE
Coverage improvements

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CoverageService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CoverageService.java
@@ -6,13 +6,17 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.e4.core.di.annotations.Creatable;
+import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.jacoco.core.analysis.Analyzer;
@@ -188,22 +192,77 @@ public class CoverageService
             reader.read();
         }
 
+        Set<String> executedClassNames = executionDataStore.getContents().stream()
+            .map( data -> data.getName() )
+            .collect( Collectors.toSet() );
+
+        if ( executedClassNames.isEmpty() )
+        {
+            return "\n--- Coverage ---\nNo execution data found in coverage file.\n";
+        }
+
         CoverageBuilder coverageBuilder = new CoverageBuilder();
         Analyzer analyzer = new Analyzer( executionDataStore, coverageBuilder );
 
+        List<File> outputLocations = new ArrayList<>();
         IProject[] allProjects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
         for ( IProject project : allProjects )
         {
-            if ( !project.isOpen() || !project.hasNature( JavaCore.NATURE_ID ) )
+            try
             {
-                continue;
+                if ( !project.isOpen() || !project.hasNature( JavaCore.NATURE_ID ) )
+                {
+                    continue;
+                }
+                IJavaProject javaProject = JavaCore.create( project );
+                Set<File> projectOutputs = new HashSet<>();
+                File defaultOutput = project.getLocation().append(
+                    javaProject.getOutputLocation().removeFirstSegments( 1 ) ).toFile();
+                projectOutputs.add( defaultOutput );
+                for ( IClasspathEntry entry : javaProject.getResolvedClasspath( true ) )
+                {
+                    if ( entry.getEntryKind() == IClasspathEntry.CPE_SOURCE && entry.getOutputLocation() != null )
+                    {
+                        File entryOutput = project.getLocation().append(
+                            entry.getOutputLocation().removeFirstSegments( 1 ) ).toFile();
+                        projectOutputs.add( entryOutput );
+                    }
+                }
+                for ( File output : projectOutputs )
+                {
+                    if ( output.exists() )
+                    {
+                        outputLocations.add( output );
+                    }
+                }
             }
-            IJavaProject javaProject = JavaCore.create( project );
-            File outputLocation = project.getLocation().append(
-                javaProject.getOutputLocation().removeFirstSegments( 1 ) ).toFile();
-            if ( outputLocation.exists() )
+            catch ( Exception e )
             {
-                analyzer.analyzeAll( outputLocation );
+                // skip projects that can't be resolved
+            }
+        }
+
+        for ( String className : executedClassNames )
+        {
+            String classFilePath = className.replace( '/', File.separatorChar ) + ".class";
+            for ( File outputLocation : outputLocations )
+            {
+                File classFile = new File( outputLocation, classFilePath );
+                if ( classFile.exists() )
+                {
+                    try ( FileInputStream fis = new FileInputStream( classFile ) )
+                    {
+                        analyzer.analyzeAll( fis, className );
+                    }
+                    catch ( Exception e )
+                    {
+                        if ( logger != null )
+                        {
+                            logger.warn( "Skipping class '" + className + "': " + e.getMessage() );
+                        }
+                    }
+                    break;
+                }
             }
         }
 

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CoverageService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CoverageService.java
@@ -47,6 +47,60 @@ public class CoverageService
         return COVERAGE_LAUNCH_MODE;
     }
 
+    public String waitForLatestCoverageFile( long launchStartTime, int maxWaitMs )
+    {
+        Path basePath = ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile().toPath()
+            .resolve( ".metadata" ).resolve( ".plugins" ).resolve( ECLEMMA_CORE_BUNDLE );
+
+        if ( !Files.exists( basePath ) )
+        {
+            return null;
+        }
+
+        int elapsed = 0;
+        int pollInterval = 500;
+        while ( elapsed < maxWaitMs )
+        {
+            try
+            {
+                var execFile = Files.walk( basePath, 2 )
+                    .filter( p -> p.toString().endsWith( ".exec" ) )
+                    .filter( p -> {
+                        try
+                        {
+                            return Files.getLastModifiedTime( p ).toMillis() >= launchStartTime;
+                        }
+                        catch ( IOException e )
+                        {
+                            return false;
+                        }
+                    } )
+                    .findFirst();
+                if ( execFile.isPresent() )
+                {
+                    return execFile.get().toString();
+                }
+            }
+            catch ( IOException e )
+            {
+                logger.error( "Error searching for coverage files", e );
+                return null;
+            }
+            try
+            {
+                Thread.sleep( pollInterval );
+            }
+            catch ( InterruptedException e )
+            {
+                Thread.currentThread().interrupt();
+                return null;
+            }
+            elapsed += pollInterval;
+        }
+        logger.warn( "Coverage exec file not found within " + maxWaitMs + "ms" );
+        return null;
+    }
+
     public String findLatestCoverageFile()
     {
         Path basePath = ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile().toPath()

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/PDEService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/PDEService.java
@@ -370,6 +370,7 @@ public class PDEService
             boolean useCoverage = withCoverage && coverageService.isCoverageAvailable();
             String launchMode = useCoverage ? coverageService.getCoverageLaunchMode() : ILaunchManager.RUN_MODE;
 
+            long launchStartTime = System.currentTimeMillis();
             CoreException[] launchError = new CoreException[1];
             sync.syncExec( () -> {
                 try
@@ -402,7 +403,7 @@ public class PDEService
 
             if ( useCoverage )
             {
-                String execFile = coverageService.findLatestCoverageFile();
+                String execFile = coverageService.waitForLatestCoverageFile( launchStartTime, 10000 );
                 results += coverageService.formatCoverageInfo( execFile, javaProject.getProject().getName() );
             }
 

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/UnitTestService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/UnitTestService.java
@@ -504,6 +504,7 @@ public class UnitTestService {
                 boolean useCoverage = withCoverage && coverageService.isCoverageAvailable();
                 String launchMode = useCoverage ? coverageService.getCoverageLaunchMode() : ILaunchManager.RUN_MODE;
                 
+                long launchStartTime = System.currentTimeMillis();
                 // Launch the tests
                 sync.syncExec(() -> {
                     try {
@@ -527,7 +528,7 @@ public class UnitTestService {
                 String results = testRunResults[0].toString();
                 
                 if (useCoverage) {
-                    String execFile = coverageService.findLatestCoverageFile();
+                    String execFile = coverageService.waitForLatestCoverageFile( launchStartTime, 10000 );
                     results += coverageService.formatCoverageInfo( execFile, javaProject.getProject().getName() );
                 }
                 

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/CoverageServiceTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/CoverageServiceTest.java
@@ -282,7 +282,7 @@ public class CoverageServiceTest
 
     @Test
     @Order( 9 )
-    public void testFormatCoverageInfo_withValidExecFile_andProject_returnsCoverageReport() throws Exception
+    public void testFormatCoverageInfo_withEmptyExecFile_andProject_returnsNoDataMessage() throws Exception
     {
         assumeTrue( coverageService.isCoverageAvailable(),
             "Skipping: EclEmma/JaCoCo not installed" );
@@ -297,8 +297,8 @@ public class CoverageServiceTest
         try
         {
             String result = coverageService.formatCoverageInfo( tempExec.toString(), TEST_PROJECT_NAME );
-            assertTrue( result.contains( "--- Coverage Report ---" ) );
-            assertTrue( result.contains( "All classes fully covered." ) || result.contains( "Classes with incomplete coverage:" ) );
+            assertTrue( result.contains( "--- Coverage ---" ) );
+            assertTrue( result.contains( "No execution data found" ) );
         }
         finally
         {


### PR DESCRIPTION
This pull request improves how code coverage is collected and reported after running tests, especially in scenarios where coverage data files may not be immediately available. It introduces a polling mechanism to reliably wait for the coverage file, enhances the analysis to target only executed classes, and updates related tests to reflect these changes.

**Coverage file detection and waiting:**
- Added `waitForLatestCoverageFile` to `CoverageService`, which polls for the coverage `.exec` file generated after test execution, ensuring that coverage data is reliably found before processing. This method replaces direct file lookup in both `PDEService` and `UnitTestService`. [[1]](diffhunk://#diff-f4d7620f6d8446d7fbb0e2a9624110d7beb1e8a351c4f3f2d1ca2d72769e3ce0R54-R107) [[2]](diffhunk://#diff-3373ca1a2136709f4d00eb215d202ace1866d9e457a3c6ab794a59b082781941R373) [[3]](diffhunk://#diff-3373ca1a2136709f4d00eb215d202ace1866d9e457a3c6ab794a59b082781941L405-R406) [[4]](diffhunk://#diff-7e8051cd41b0596a6605474338fe1247a162029ae24f301ad12bec454e0df839R507) [[5]](diffhunk://#diff-7e8051cd41b0596a6605474338fe1247a162029ae24f301ad12bec454e0df839L530-R531)

**Coverage analysis improvements:**
- Modified the coverage analysis logic to only analyze class files that have execution data, improving efficiency and accuracy. It now gathers output locations from all relevant source folders in all open Java projects and processes only those classes that were actually executed.

**Testing updates:**
- Updated the coverage test to check for the new "No execution data found" message when the coverage file is empty, reflecting the improved reporting in the coverage summary. [[1]](diffhunk://#diff-1334100ac17fc0d0004b4a3a57d6bec27b38c9afbda6fd29a366fffc01772fddL285-R285) [[2]](diffhunk://#diff-1334100ac17fc0d0004b4a3a57d6bec27b38c9afbda6fd29a366fffc01772fddL300-R301)