### PR TITLE
Pde and test default fixes

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/PDEService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/PDEService.java
@@ -218,7 +218,7 @@ public class PDEService
         }
         if ( timeout == null || timeout <= 0 )
         {
-            timeout = 120;
+            timeout = 300;
         }
 
         try
@@ -246,7 +246,7 @@ public class PDEService
         Objects.requireNonNull( className, "Class name cannot be null" );
         if ( timeout == null || timeout <= 0 )
         {
-            timeout = 120;
+            timeout = 300;
         }
 
         try

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/PDEService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/PDEService.java
@@ -34,6 +34,7 @@ import org.eclipse.pde.core.target.ITargetHandle;
 import org.eclipse.pde.core.target.ITargetPlatformService;
 import org.eclipse.pde.core.target.LoadTargetDefinitionJob;
 import org.eclipse.pde.launching.IPDELauncherConstants;
+import org.eclipse.swt.widgets.Display;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -371,24 +372,42 @@ public class PDEService
             String launchMode = useCoverage ? coverageService.getCoverageLaunchMode() : ILaunchManager.RUN_MODE;
 
             CoreException[] launchError = new CoreException[1];
-            sync.syncExec( () -> {
+            org.eclipse.debug.core.ILaunch[] launchRef = new org.eclipse.debug.core.ILaunch[1];
+            sync.asyncExec( () -> {
                 try
                 {
-                    configuration.launch( launchMode, new NullProgressMonitor() );
+                    launchRef[0] = configuration.launch( launchMode, new NullProgressMonitor() );
                 }
                 catch ( CoreException e )
                 {
                     launchError[0] = e;
+                    latch.countDown();
                     logger.log( org.eclipse.core.runtime.Status.error( "Error launching plug-in tests", e ) );
                 }
             } );
+
+            long deadline = System.currentTimeMillis() + timeout * 1000L;
+            Display display = Display.getCurrent();
+            boolean completed = false;
+            while ( !completed && System.currentTimeMillis() < deadline )
+            {
+                if ( display != null && !display.isDisposed() )
+                {
+                    while ( display.readAndDispatch() )
+                    {
+                    }
+                }
+                completed = latch.await( 100, TimeUnit.MILLISECONDS );
+                if ( !completed && launchRef[0] != null && launchRef[0].isTerminated() )
+                {
+                    completed = true;
+                }
+            }
 
             if ( launchError[0] != null )
             {
                 return "Error launching plug-in tests: " + launchError[0].getMessage();
             }
-
-            boolean completed = latch.await( timeout, TimeUnit.SECONDS );
             if ( !completed )
             {
                 return "Error: Test execution timed out after " + timeout + " seconds.";

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/UnitTestService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/UnitTestService.java
@@ -154,7 +154,7 @@ public class UnitTestService {
         }
         
         if (timeout == null || timeout <= 0) {
-            timeout = 60; // Default timeout of 60 seconds
+            timeout = 300; // Default timeout of 300 seconds
         }
         
         try {
@@ -193,7 +193,7 @@ public class UnitTestService {
         }
         
         if (timeout == null || timeout <= 0) {
-            timeout = 60; // Default timeout of 60 seconds
+            timeout = 300; // Default timeout of 300 seconds
         }
         
         try {
@@ -238,7 +238,7 @@ public class UnitTestService {
         }
         
         if (timeout == null || timeout <= 0) {
-            timeout = 60; // Default timeout of 60 seconds
+            timeout = 300; // Default timeout of 300 seconds
         }
         
         try {
@@ -289,7 +289,7 @@ public class UnitTestService {
         }
         
         if (timeout == null || timeout <= 0) {
-            timeout = 60; // Default timeout of 60 seconds
+            timeout = 300; // Default timeout of 300 seconds
         }
         
         try {


### PR DESCRIPTION
This pull request increases the default timeout for running both PDE and unit tests from 60 or 120 seconds to 300 seconds, addressing issues with longer-running tests. Additionally, it improves the way plugin test launches are handled in the Eclipse UI thread to better support timeouts and UI responsiveness.

Timeout increases for test execution:

* Increased the default timeout for all unit test methods in `UnitTestService` (`runAllTests`, `runPackageTests`, `runClassTests`, and `runTestMethod`) from 60 seconds to 300 seconds. [[1]](diffhunk://#diff-7e8051cd41b0596a6605474338fe1247a162029ae24f301ad12bec454e0df839L157-R157) [[2]](diffhunk://#diff-7e8051cd41b0596a6605474338fe1247a162029ae24f301ad12bec454e0df839L196-R196) [[3]](diffhunk://#diff-7e8051cd41b0596a6605474338fe1247a162029ae24f301ad12bec454e0df839L241-R241) [[4]](diffhunk://#diff-7e8051cd41b0596a6605474338fe1247a162029ae24f301ad12bec454e0df839L292-R292)
* Increased the default timeout for PDE test execution methods (`runJUnitPluginTests` and `runJUnitPluginTestClass` in `PDEService`) from 120 seconds to 300 seconds. [[1]](diffhunk://#diff-3373ca1a2136709f4d00eb215d202ace1866d9e457a3c6ab794a59b082781941L221-R222) [[2]](diffhunk://#diff-3373ca1a2136709f4d00eb215d202ace1866d9e457a3c6ab794a59b082781941L249-R250)

Improvements to PDE test launch handling:

* Changed the plugin test launch in `PDEService` to use `asyncExec` instead of `syncExec`, and added logic to process the SWT event loop and check for launch completion or timeout, improving UI responsiveness and reliability of timeouts.
* Added import for `org.eclipse.swt.widgets.Display` to support the new event loop handling.