### PR TITLE
Skip bearer token auth for localhost requests

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/http/BearerTokenAuthenticationValve.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/http/BearerTokenAuthenticationValve.java
@@ -21,6 +21,12 @@ public class BearerTokenAuthenticationValve extends ValveBase
     @Override
     public void invoke( Request request, Response response ) throws IOException, ServletException
     {
+        if ( isLocalRequest( request ) )
+        {
+            getNext().invoke( request, response );
+            return;
+        }
+
         String authHeader = request.getHeader( "Authorization" );
 
         if ( authHeader == null || !authHeader.startsWith( "Bearer " ) )
@@ -42,5 +48,13 @@ public class BearerTokenAuthenticationValve extends ValveBase
         }
 
         getNext().invoke( request, response );
+    }
+
+    private boolean isLocalRequest( Request request )
+    {
+        String remoteAddr = request.getRemoteAddr();
+        return "127.0.0.1".equals( remoteAddr )
+            || "0:0:0:0:0:0:0:1".equals( remoteAddr )
+            || "::1".equals( remoteAddr );
     }
 }


### PR DESCRIPTION
i don't really like that if i have an opencode.json that that connects to a local mcp server inside my eclipse that i need to have a bearer token, because i do want to commit this and committing bearer tokens is a bit weird (those should kind of be private)\

But if you are fully local i don't really see the reason to mandate a bearer token header, all should just be allowed as far as i can see.

Or do you have a different idea about this?