### PR TITLE
feat: support multiple workspace connections (multi MCP server)

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/McpServerFactory.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/McpServerFactory.java
@@ -171,15 +171,20 @@ public class McpServerFactory
 
     public McpSyncServer createSyncServer( Object serverImplementation, McpServerTransportProvider transportProvider )
     {
-        return createSyncServer( serverImplementation, transportProvider, Collections.emptySet() );
+        return createSyncServer( serverImplementation, transportProvider, Collections.emptySet(), "" );
     }
 
     public McpSyncServer createSyncServer( Object serverImplementation, McpServerTransportProvider transportProvider, Collection<String> excludedTools )
     {
+        return createSyncServer( serverImplementation, transportProvider, excludedTools, "" );
+    }
+
+    public McpSyncServer createSyncServer( Object serverImplementation, McpServerTransportProvider transportProvider, Collection<String> excludedTools, String toolPrefix )
+    {
         requireMcpServerAnnotation( serverImplementation );
 
         var info     = createImplementationInfo( serverImplementation );
-        var toolSpecifications = createToolSpecifications( serverImplementation, excludedTools );
+        var toolSpecifications = createToolSpecifications( serverImplementation, excludedTools, toolPrefix );
         var capabilities = createCapabilities();
         return McpServer.sync( transportProvider )
                         .serverInfo( info )
@@ -192,15 +197,20 @@ public class McpServerFactory
 
     public McpSyncServer createSyncServer( Object serverImplementation, HttpServletStreamableServerTransportProvider transportProvider )
     {
-        return createSyncServer( serverImplementation, transportProvider, Collections.emptySet() );
+        return createSyncServer( serverImplementation, transportProvider, Collections.emptySet(), "" );
     }
 
     public McpSyncServer createSyncServer( Object serverImplementation, HttpServletStreamableServerTransportProvider transportProvider, Collection<String> excludedTools )
     {
+        return createSyncServer( serverImplementation, transportProvider, excludedTools, "" );
+    }
+
+    public McpSyncServer createSyncServer( Object serverImplementation, HttpServletStreamableServerTransportProvider transportProvider, Collection<String> excludedTools, String toolPrefix )
+    {
         requireMcpServerAnnotation( serverImplementation );
 
         var info     = createImplementationInfo( serverImplementation );
-        var toolSpecifications = createToolSpecifications( serverImplementation, excludedTools );
+        var toolSpecifications = createToolSpecifications( serverImplementation, excludedTools, toolPrefix );
         var capabilities = createCapabilities();
         return McpServer.sync( transportProvider )
                 .serverInfo( info )
@@ -211,9 +221,10 @@ public class McpServerFactory
                 .build();
     }
 
-    private List<SyncToolSpecification> createToolSpecifications( Object serverImplementation, Collection<String> excludedTools )
+    private List<SyncToolSpecification> createToolSpecifications( Object serverImplementation, Collection<String> excludedTools, String toolPrefix )
     {
         var excluded = Set.copyOf( excludedTools );
+        var prefix = (toolPrefix != null && !toolPrefix.isBlank()) ? toolPrefix : "";
         var executor = new ToolExecutor( serverImplementation );
         var tools    = extractAnnotatedTools( executor.getFunctions() );
         if ( tools.isEmpty() )
@@ -222,12 +233,14 @@ public class McpServerFactory
         }
         var toolSpecifications = tools.stream()
                 .filter( tool -> !excluded.contains( tool.name() ) )
-                .map( tool -> 
-                    McpServerFeatures.SyncToolSpecification.builder()
-                    .tool( tool )
-                    .callHandler( (exchange, request) ->  executeCallTool( executor, tool, request.arguments() ) )
-                    .build()
-                ).collect( Collectors.toList() );
+                .map( tool -> {
+                    var prefixedTool = prefix.isEmpty() ? tool : new McpSchema.Tool(
+                            prefix + tool.name(), prefix + tool.name(), tool.description(), tool.inputSchema(), tool.outputSchema(), tool.annotations(), tool.meta() );
+                    return McpServerFeatures.SyncToolSpecification.builder()
+                        .tool( prefixedTool )
+                        .callHandler( (exchange, request) ->  executeCallTool( executor, tool, request.arguments() ) )
+                        .build();
+                }).collect( Collectors.toList() );
         
         return toolSpecifications;
     }

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/http/HttpMcpServerPreferences.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/http/HttpMcpServerPreferences.java
@@ -1,3 +1,3 @@
 package com.github.gradusnikov.eclipse.assistai.mcp.http;
 
-public record HttpMcpServerPreferences ( int port, String hostname, String token ) {};
+public record HttpMcpServerPreferences ( int port, String hostname, String token, String toolPrefix ) {};

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/http/HttpMcpServerPreferencesProvider.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/http/HttpMcpServerPreferencesProvider.java
@@ -18,8 +18,9 @@ public class HttpMcpServerPreferencesProvider
         String hostname = preferenceStore.getString(com.github.gradusnikov.eclipse.assistai.preferences.PreferenceConstants.ASSISTAI_MCP_HTTP_HOSTNAME);
         int port = preferenceStore.getInt(com.github.gradusnikov.eclipse.assistai.preferences.PreferenceConstants.ASSISTAI_MCP_HTTP_PORT);
         String token = preferenceStore.getString(com.github.gradusnikov.eclipse.assistai.preferences.PreferenceConstants.ASSISTAI_MCP_HTTP_AUTH_TOKEN);
+        String toolPrefix = preferenceStore.getString(com.github.gradusnikov.eclipse.assistai.preferences.PreferenceConstants.ASSISTAI_MCP_HTTP_TOOL_PREFIX);
 
-        return new HttpMcpServerPreferences(port, hostname, token);
+        return new HttpMcpServerPreferences(port, hostname, token, toolPrefix);
     }
 
     public void save(HttpMcpServerPreferences preferences)
@@ -29,6 +30,7 @@ public class HttpMcpServerPreferencesProvider
         preferenceStore.setValue(com.github.gradusnikov.eclipse.assistai.preferences.PreferenceConstants.ASSISTAI_MCP_HTTP_HOSTNAME, preferences.hostname());
         preferenceStore.setValue(com.github.gradusnikov.eclipse.assistai.preferences.PreferenceConstants.ASSISTAI_MCP_HTTP_PORT, preferences.port());
         preferenceStore.setValue(com.github.gradusnikov.eclipse.assistai.preferences.PreferenceConstants.ASSISTAI_MCP_HTTP_AUTH_TOKEN, preferences.token());
+        preferenceStore.setValue(com.github.gradusnikov.eclipse.assistai.preferences.PreferenceConstants.ASSISTAI_MCP_HTTP_TOOL_PREFIX, preferences.toolPrefix());
     }
 
     public boolean isEnabled()
@@ -51,6 +53,7 @@ public class HttpMcpServerPreferencesProvider
         preferenceStore.setToDefault(com.github.gradusnikov.eclipse.assistai.preferences.PreferenceConstants.ASSISTAI_MCP_HTTP_PORT);
         preferenceStore.setToDefault(com.github.gradusnikov.eclipse.assistai.preferences.PreferenceConstants.ASSISTAI_MCP_HTTP_AUTH_TOKEN);
         preferenceStore.setToDefault(com.github.gradusnikov.eclipse.assistai.preferences.PreferenceConstants.ASSISTAI_MCP_HTTP_ENABLED);
+        preferenceStore.setToDefault(com.github.gradusnikov.eclipse.assistai.preferences.PreferenceConstants.ASSISTAI_MCP_HTTP_TOOL_PREFIX);
     }
 
 }

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/http/HttpMcpServerRegistry.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/http/HttpMcpServerRegistry.java
@@ -99,6 +99,7 @@ public class HttpMcpServerRegistry
     
     private void initializeBuiltInServers(Context context, List<McpServerDescriptor> stored, List<McpServerDescriptor> builtin )
     {
+        String toolPrefix = httpServerPreferncesProvider.get().toolPrefix();
         for ( McpServerDescriptor builtInServerDescriptor : builtin )
         {
             McpServerDescriptor updated = stored.stream()
@@ -110,7 +111,7 @@ public class HttpMcpServerRegistry
             {
                 var implementation = mcpServerRepository.makeImplementation( updated.name() );
                 var transportProvider = createStreamableHttpTransportProvider( updated.name() );
-                var server = mcpServerFactory.createSyncServer( implementation, transportProvider, updated.excludedTools() );
+                var server = mcpServerFactory.createSyncServer( implementation, transportProvider, updated.excludedTools(), toolPrefix );
                 servers.add( server );
                 addServlet(context, updated.name(), transportProvider);  // Pass context and name
             }

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/preferences/PreferenceConstants.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/preferences/PreferenceConstants.java
@@ -17,6 +17,7 @@ public class PreferenceConstants
     public static final String ASSISTAI_MCP_HTTP_PORT = "AssistAIMcpHttpPort";
     public static final String ASSISTAI_MCP_HTTP_AUTH_TOKEN = "AssistAIMcpHttpToken";
     public static final String ASSISTAI_MCP_HTTP_ENABLED = "AssistAIMcpHttpEnabled";
+    public static final String ASSISTAI_MCP_HTTP_TOOL_PREFIX = "AssistAIMcpHttpToolPrefix";
     
     // Code Completion preferences
     public static final String ASSISTAI_COMPLETION_ENABLED = "AssistAICompletionEnabled";

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/preferences/mcp/McpHttpServerPreferencePage.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/preferences/mcp/McpHttpServerPreferencePage.java
@@ -38,6 +38,7 @@ public class McpHttpServerPreferencePage extends PreferencePage implements IWork
     private Text hostnameText;
     private Text portText;
     private Text tokenText;
+    private Text toolPrefixText;
     private Button enabledCheckbox;
     private Button generateTokenButton;
     private Button copyTokenButton;
@@ -160,6 +161,16 @@ public class McpHttpServerPreferencePage extends PreferencePage implements IWork
                 }
             }
         });
+
+        // Tool Prefix field
+        Label toolPrefixLabel = new Label(configGroup, SWT.NONE);
+        toolPrefixLabel.setText("Tool Prefix:");
+
+        toolPrefixText = new Text(configGroup, SWT.BORDER);
+        toolPrefixText.setToolTipText("Optional prefix prepended to all tool names (e.g. 'tor_' makes 'listProjects' become 'tor_listProjects')");
+        GridData toolPrefixData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+        toolPrefixData.horizontalSpan = 2;
+        toolPrefixText.setLayoutData(toolPrefixData);
     }
 
     private void createServerStatusGroup(Composite parent)
@@ -267,9 +278,10 @@ public class McpHttpServerPreferencePage extends PreferencePage implements IWork
         int port = Integer.parseInt(portText.getText().trim());
         String hostname = hostnameText.getText().trim();
         String token = tokenText.getText().trim();
+        String toolPrefix = toolPrefixText.getText().trim();
         boolean enabled = enabledCheckbox.getSelection();
 
-        presenter.savePreferences(port, hostname, token, enabled);
+        presenter.savePreferences(port, hostname, token, toolPrefix, enabled);
     }
 
     @Override
@@ -291,6 +303,7 @@ public class McpHttpServerPreferencePage extends PreferencePage implements IWork
             hostnameText.setText(prefs.hostname() );
             portText.setText(Integer.toString( prefs.port() ));
             tokenText.setText(prefs.token());
+            toolPrefixText.setText( prefs.toolPrefix() != null ? prefs.toolPrefix() : "" );
         });
     }
 

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/preferences/mcp/McpHttpServerPreferencePresenter.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/preferences/mcp/McpHttpServerPreferencePresenter.java
@@ -48,9 +48,9 @@ public class McpHttpServerPreferencePresenter
      * @param token the authentication token
      * @param enabled whether the server is enabled
      */
-    public void savePreferences(int port, String hostname, String token, boolean enabled)
+    public void savePreferences(int port, String hostname, String token, String toolPrefix, boolean enabled)
     {
-        HttpMcpServerPreferences preferences = new HttpMcpServerPreferences(port, hostname, token);
+        HttpMcpServerPreferences preferences = new HttpMcpServerPreferences(port, hostname, token, toolPrefix);
         preferencesProvider.save(preferences);
         preferencesProvider.setEnabled(enabled);
         
@@ -108,7 +108,7 @@ public class McpHttpServerPreferencePresenter
     public void onGenerateNewToken()
     {
         var old =  preferencesProvider.get();
-        HttpMcpServerPreferences preferences = new HttpMcpServerPreferences(old.port(), old.hostname(), generateToken());
+        HttpMcpServerPreferences preferences = new HttpMcpServerPreferences(old.port(), old.hostname(), generateToken(), old.toolPrefix());
         preferencesProvider.save(preferences);
         
         logger.info( "MCP Http server preferences updated" );


### PR DESCRIPTION
 ## Summary
  Add support for connecting to multiple Eclipse workspaces simultaneously via multiple MCP HTTP server instances.

  ## Changes
  - Updated `McpServerFactory` to handle multiple server configurations
  - Extended `HttpMcpServerPreferences` and `HttpMcpServerPreferencesProvider` to support multiple endpoints
  - Modified `HttpMcpServerRegistry` for multi-server management
  - Added new preference constant for multi-workspace configuration
  - Updated preference page and presenter to allow users to configure multiple workspace connections