### PR TITLE
feat(eclipse-runner): launch existing launch configurations + stop polluting the config list

### DIFF
--- a/.claude/skills/eclipse-debug/SKILL.md
+++ b/.claude/skills/eclipse-debug/SKILL.md
@@ -2,7 +2,7 @@
 name: eclipse-debug
 description: Debug Java applications in Eclipse — set breakpoints, launch in debug mode, step through code, inspect stack traces, evaluate expressions, and hot-swap code changes.
 argument-hint: [project] [main class]
-allowed-tools: mcp__eclipse-runner__debugJavaApplication, mcp__eclipse-runner__stopApplication, mcp__eclipse-runner__listActiveLaunches, mcp__eclipse-runner__toggleBreakpoint, mcp__eclipse-runner__setConditionalBreakpoint, mcp__eclipse-runner__listBreakpoints, mcp__eclipse-runner__removeAllBreakpoints, mcp__eclipse-runner__getStackTrace, mcp__eclipse-runner__evaluateExpression, mcp__eclipse-runner__resumeDebug, mcp__eclipse-runner__stepOver, mcp__eclipse-runner__stepInto, mcp__eclipse-runner__stepReturn, mcp__eclipse-runner__hotCodeReplace, mcp__eclipse-ide__getConsoleOutput
+allowed-tools: mcp__eclipse-runner__debugJavaApplication, mcp__eclipse-runner__launchConfiguration, mcp__eclipse-runner__listLaunchConfigurations, mcp__eclipse-runner__stopApplication, mcp__eclipse-runner__listActiveLaunches, mcp__eclipse-runner__toggleBreakpoint, mcp__eclipse-runner__setConditionalBreakpoint, mcp__eclipse-runner__listBreakpoints, mcp__eclipse-runner__removeAllBreakpoints, mcp__eclipse-runner__getStackTrace, mcp__eclipse-runner__evaluateExpression, mcp__eclipse-runner__resumeDebug, mcp__eclipse-runner__stepOver, mcp__eclipse-runner__stepInto, mcp__eclipse-runner__stepReturn, mcp__eclipse-runner__hotCodeReplace, mcp__eclipse-ide__getConsoleOutput
 ---
 
 # Debug Java Applications in Eclipse
@@ -19,6 +19,7 @@ Full interactive debugging using Eclipse's JDT debugger. Set breakpoints, step t
 ## Launch
 
 - **debugJavaApplication** — Launch in debug mode. Same parameters as `runJavaApplication` but defaults to `timeout=0` (background). The app stops at breakpoints.
+- **launchConfiguration** — Debug an *existing saved* launch configuration by name with `mode="debug"`, preserving its classpath, VM args, environment variables, working directory, and agent settings (e.g. JRebel). Use `listLaunchConfigurations` to find the name. Breakpoints set via `toggleBreakpoint` still apply.
 
 ## Stepping (requires suspended thread)
 

--- a/.claude/skills/eclipse-run/SKILL.md
+++ b/.claude/skills/eclipse-run/SKILL.md
@@ -2,7 +2,7 @@
 name: eclipse-run
 description: Launch and stop Java applications in Eclipse. Run with program/VM arguments, capture stdout/stderr, or launch in background.
 argument-hint: [project] [main class]
-allowed-tools: mcp__eclipse-runner__runJavaApplication, mcp__eclipse-runner__stopApplication, mcp__eclipse-runner__listActiveLaunches, mcp__eclipse-ide__getConsoleOutput
+allowed-tools: mcp__eclipse-runner__runJavaApplication, mcp__eclipse-runner__launchConfiguration, mcp__eclipse-runner__listLaunchConfigurations, mcp__eclipse-runner__stopApplication, mcp__eclipse-runner__listActiveLaunches, mcp__eclipse-ide__getConsoleOutput
 ---
 
 # Run Java Applications in Eclipse
@@ -17,6 +17,13 @@ Launch Java applications using Eclipse's launch infrastructure. Applications run
   - `programArgs` — Optional program arguments
   - `vmArgs` — Optional JVM arguments (e.g., `-Xmx512m -Dfoo=bar`)
   - `timeout` — Seconds to wait for completion. `0` = launch in background without waiting. Default: `30`
+
+- **launchConfiguration** — Launch an *existing saved* launch configuration by name, exactly as it would run from the Run/Debug Configurations dialog. Reuses the configuration's full setup (classpath, VM args, environment variables, working directory, JRebel/agent settings) instead of building a throwaway one.
+  - `configurationName` — Exact name of the saved configuration (use `listLaunchConfigurations` to find it)
+  - `mode` — `run` or `debug`. Default: `run`
+  - `timeout` — Seconds to wait for completion. `0` = background. Default: `0`
+
+- **listLaunchConfigurations** — List saved launch configurations (name, type, and project/main class for Java apps). Use this to discover the exact name for `launchConfiguration`.
 
 - **stopApplication** — Terminate a running application by name/class substring match.
   - `nameOrClass` — Substring to match (case-insensitive) against launch name or main class
@@ -40,6 +47,12 @@ runJavaApplication(projectName="myapp", mainClass="com.example.Server", timeout=
 **Run with arguments:**
 ```
 runJavaApplication(projectName="myapp", mainClass="com.example.CLI", programArgs="--verbose input.txt", vmArgs="-Xmx1g")
+```
+
+**Launch an existing saved configuration (preserves its env vars, VM args, JRebel, etc.):**
+```
+listLaunchConfigurations()
+launchConfiguration(configurationName="Run Snapshot App No Data Compass Local", mode="debug", timeout="0")
 ```
 
 **Stop a running app:**

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ External agents don't know what you're looking at in Eclipse -- unless they ask.
 |------|-------------|
 | runJavaApplication | Launch in run mode with optional arguments and timeout |
 | debugJavaApplication | Launch in debug mode, stops at breakpoints |
+| launchConfiguration | Launch an existing saved launch configuration by name (reuses its classpath, VM args, env, working dir, JRebel, etc.) in run or debug mode |
+| listLaunchConfigurations | List saved launch configurations (name, type, project, main class) |
 | stopApplication | Stop a running/debugging application |
 | listActiveLaunches | List all running/debugging applications |
 | toggleBreakpoint | Set or remove a line breakpoint |

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/EclipseRunnerMcpServer.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/EclipseRunnerMcpServer.java
@@ -63,6 +63,27 @@ public class EclipseRunnerMcpServer
         return javaLaunchService.listActiveLaunches();
     }
 
+    @Tool(name = "listLaunchConfigurations",
+          description = "Lists all saved launch configurations in the workspace (name, type, and for Java applications the project and main class). Use this to discover the exact name to pass to launchConfiguration.",
+          type = "object")
+    public String listLaunchConfigurations()
+    {
+        return javaLaunchService.listLaunchConfigurations();
+    }
+
+    @Tool(name = "launchConfiguration",
+          description = "Launches an existing saved launch configuration by name, exactly as it would run from Eclipse's Run/Debug Configurations dialog (reusing its classpath, program/VM arguments, environment variables, working directory, and agent settings such as JRebel). Use listLaunchConfigurations to find the name. Unlike runJavaApplication/debugJavaApplication, this does NOT create a throwaway configuration. If timeout > 0, waits for the process to finish and returns stdout/stderr; if timeout = 0, launches in background and returns immediately.",
+          type = "object")
+    public String launchConfiguration(
+            @ToolParam(name = "configurationName", description = "The exact name of the launch configuration to launch (e.g., 'Run Snapshot App No Data Compass Local')") String configurationName,
+            @ToolParam(name = "mode", description = "Launch mode: 'run' or 'debug'. Default: 'run'", required = false) String mode,
+            @ToolParam(name = "timeout", description = "Timeout in seconds to wait for completion. Use '0' to launch in background without waiting. Default: '0'", required = false) String timeout)
+    {
+        int timeoutSeconds = Optional.ofNullable(timeout).map(Integer::parseInt).orElse(0);
+        String launchMode = Optional.ofNullable(mode).filter(m -> !m.isBlank()).orElse("run");
+        return javaLaunchService.launchConfiguration(configurationName, launchMode, timeoutSeconds);
+    }
+
     @Tool(name = "toggleBreakpoint",
           description = "Sets or removes a line breakpoint at the specified location. If a breakpoint already exists at the line, it is removed. Otherwise, a new breakpoint is created.",
           type = "object")

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/JavaLaunchService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/JavaLaunchService.java
@@ -140,120 +140,260 @@ public class JavaLaunchService
                         vmArgs);
             }
 
-            ILaunchConfiguration configuration = workingCopy.doSave();
-
-            // Capture output
-            var outputBuffer = new StringBuilder();
-            var errorBuffer = new StringBuilder();
-            // Launch
-            final ILaunch[] launchHolder = new ILaunch[1];
-            sync.syncExec(() ->
-            {
-                try
-                {
-                    launchHolder[0] = configuration.launch(mode, new NullProgressMonitor());
-                }
-                catch (CoreException e)
-                {
-                    logger.error("Error launching application", e);
-                }
-            });
-
-            ILaunch launch = launchHolder[0];
-            if (launch == null)
-            {
-                return "Error: Failed to launch application.";
-            }
-
-            // Attach stream listeners to capture output
-            for (IProcess process : launch.getProcesses())
-            {
-                IStreamMonitor stdoutMonitor = process.getStreamsProxy().getOutputStreamMonitor();
-                IStreamMonitor stderrMonitor = process.getStreamsProxy().getErrorStreamMonitor();
-
-                // Capture any content already buffered
-                String existingOut = stdoutMonitor.getContents();
-                if (existingOut != null && !existingOut.isEmpty())
-                {
-                    outputBuffer.append(existingOut);
-                }
-                String existingErr = stderrMonitor.getContents();
-                if (existingErr != null && !existingErr.isEmpty())
-                {
-                    errorBuffer.append(existingErr);
-                }
-
-                stdoutMonitor.addListener(new IStreamListener()
-                {
-                    @Override
-                    public void streamAppended(String text, IStreamMonitor monitor)
-                    {
-                        outputBuffer.append(text);
-                    }
-                });
-                stderrMonitor.addListener(new IStreamListener()
-                {
-                    @Override
-                    public void streamAppended(String text, IStreamMonitor monitor)
-                    {
-                        errorBuffer.append(text);
-                    }
-                });
-            }
-
-            String modeLabel = ILaunchManager.DEBUG_MODE.equals(mode) ? "debug" : "run";
-
-            if (timeout > 0)
-            {
-                // Wait for process to finish
-                boolean terminated = waitForTermination(launch, timeout);
-
-                var result = new StringBuilder();
-                result.append("Application '").append(mainClass).append("' launched in ").append(modeLabel).append(" mode.\n");
-
-                if (!terminated)
-                {
-                    result.append("Note: Process still running after ").append(timeout).append("s timeout.\n");
-                }
-                else
-                {
-                    // Get exit code
-                    for (IProcess process : launch.getProcesses())
-                    {
-                        int exitValue = process.getExitValue();
-                        result.append("Exit code: ").append(exitValue).append("\n");
-                    }
-                }
-
-                if (outputBuffer.length() > 0)
-                {
-                    result.append("\n--- stdout ---\n").append(truncateOutput(outputBuffer.toString(), 5000));
-                }
-                if (errorBuffer.length() > 0)
-                {
-                    result.append("\n--- stderr ---\n").append(truncateOutput(errorBuffer.toString(), 2000));
-                }
-
-                // Clean up configuration for short-lived runs
-                if (terminated)
-                {
-                    try { configuration.delete(); } catch (CoreException e) { /* ignore */ }
-                }
-
-                return result.toString();
-            }
-            else
-            {
-                // Don't wait â return immediately
-                return "Application '" + mainClass + "' launched in " + modeLabel + " mode. " +
-                       "Use stopApplication to terminate it, or getConsoleOutput to see its output.";
-            }
+            // Launch the in-memory working copy directly. We deliberately do NOT
+            // doSave() it: saving adds a throwaway "AssistAI-<Class>-<timestamp>"
+            // entry to the user's Run/Debug Configurations list on every launch,
+            // and the previous cleanup only deleted it for terminated timed runs
+            // (never for background launches), so those entries accumulated.
+            return executeLaunch(workingCopy, "Application '" + mainClass + "'", mode, timeout);
         }
         catch (Exception e)
         {
             logger.error("Error launching Java application", e);
             return "Error: " + e.getMessage();
         }
+    }
+
+    /**
+     * Launches an existing, saved launch configuration by name, reusing its full
+     * setup: classpath, program/VM arguments, environment variables, working
+     * directory, and any agent settings (e.g. JRebel). Unlike
+     * {@link #runJavaApplication}/{@link #debugJavaApplication}, this does not
+     * create a new configuration.
+     *
+     * @param configurationName The exact name of the launch configuration (see {@link #listLaunchConfigurations})
+     * @param mode "run" or "debug" (anything else defaults to run)
+     * @param timeout Timeout in seconds to wait for the process to finish (0 = don't wait)
+     * @return A status message with launch info or captured output
+     */
+    public String launchConfiguration(String configurationName, String mode, int timeout)
+    {
+        Objects.requireNonNull(configurationName, "Configuration name cannot be null");
+
+        String launchMode = ILaunchManager.DEBUG_MODE.equalsIgnoreCase(mode)
+                ? ILaunchManager.DEBUG_MODE
+                : ILaunchManager.RUN_MODE;
+
+        try
+        {
+            ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
+            ILaunchConfiguration configuration = findLaunchConfigurationByName(launchManager, configurationName);
+            if (configuration == null)
+            {
+                return "Error: No launch configuration named '" + configurationName
+                        + "' found. Use listLaunchConfigurations to see the available names.";
+            }
+            if (!configuration.supportsMode(launchMode))
+            {
+                return "Error: Launch configuration '" + configuration.getName()
+                        + "' does not support " + launchMode + " mode.";
+            }
+            return executeLaunch(configuration,
+                    "Launch configuration '" + configuration.getName() + "'", launchMode, timeout);
+        }
+        catch (Exception e)
+        {
+            logger.error("Error launching configuration", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    /**
+     * Lists all saved launch configurations in the workspace, with their type and
+     * (for Java application configurations) project and main class. Use this to
+     * discover the exact name to pass to {@link #launchConfiguration}.
+     *
+     * @return A formatted list of launch configurations
+     */
+    public String listLaunchConfigurations()
+    {
+        try
+        {
+            ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
+            ILaunchConfiguration[] configurations = launchManager.getLaunchConfigurations();
+
+            if (configurations.length == 0)
+            {
+                return "No launch configurations found.";
+            }
+
+            var result = new StringBuilder();
+            result.append("Launch configurations (").append(configurations.length).append("):\n");
+
+            for (ILaunchConfiguration configuration : configurations)
+            {
+                result.append("- ").append(configuration.getName());
+                try
+                {
+                    result.append(" [").append(configuration.getType().getName()).append("]");
+                }
+                catch (CoreException e) { /* type unavailable - skip */ }
+
+                String projectName = configuration.getAttribute(
+                        IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, "");
+                String mainType = configuration.getAttribute(
+                        IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, "");
+                if (!projectName.isEmpty())
+                {
+                    result.append(" project=").append(projectName);
+                }
+                if (!mainType.isEmpty())
+                {
+                    result.append(" main=").append(mainType);
+                }
+                result.append("\n");
+            }
+
+            return result.toString();
+        }
+        catch (Exception e)
+        {
+            logger.error("Error listing launch configurations", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    /**
+     * Finds a saved launch configuration by name: exact match first, then a
+     * case-insensitive fallback.
+     */
+    private ILaunchConfiguration findLaunchConfigurationByName(ILaunchManager launchManager, String name)
+            throws CoreException
+    {
+        ILaunchConfiguration[] configurations = launchManager.getLaunchConfigurations();
+        for (ILaunchConfiguration configuration : configurations)
+        {
+            if (configuration.getName().equals(name))
+            {
+                return configuration;
+            }
+        }
+        for (ILaunchConfiguration configuration : configurations)
+        {
+            if (configuration.getName().equalsIgnoreCase(name))
+            {
+                return configuration;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Launches the given configuration (which may be an unsaved working copy or a
+     * persisted configuration), attaches stream listeners, and either waits for
+     * termination returning captured output (timeout &gt; 0) or returns
+     * immediately (timeout == 0).
+     *
+     * @param configuration The configuration (or working copy) to launch
+     * @param subject A human-readable subject for status messages (e.g. "Application 'com.example.Main'")
+     * @param mode {@link ILaunchManager#RUN_MODE} or {@link ILaunchManager#DEBUG_MODE}
+     * @param timeout Timeout in seconds to wait for the process to finish (0 = don't wait)
+     */
+    private String executeLaunch(ILaunchConfiguration configuration, String subject, String mode, int timeout)
+    {
+        var outputBuffer = new StringBuilder();
+        var errorBuffer = new StringBuilder();
+
+        final ILaunch[] launchHolder = new ILaunch[1];
+        sync.syncExec(() ->
+        {
+            try
+            {
+                launchHolder[0] = configuration.launch(mode, new NullProgressMonitor());
+            }
+            catch (CoreException e)
+            {
+                logger.error("Error launching application", e);
+            }
+        });
+
+        ILaunch launch = launchHolder[0];
+        if (launch == null)
+        {
+            return "Error: Failed to launch " + subject + ".";
+        }
+
+        // Attach stream listeners to capture output
+        for (IProcess process : launch.getProcesses())
+        {
+            IStreamMonitor stdoutMonitor = process.getStreamsProxy().getOutputStreamMonitor();
+            IStreamMonitor stderrMonitor = process.getStreamsProxy().getErrorStreamMonitor();
+
+            // Capture any content already buffered
+            String existingOut = stdoutMonitor.getContents();
+            if (existingOut != null && !existingOut.isEmpty())
+            {
+                outputBuffer.append(existingOut);
+            }
+            String existingErr = stderrMonitor.getContents();
+            if (existingErr != null && !existingErr.isEmpty())
+            {
+                errorBuffer.append(existingErr);
+            }
+
+            stdoutMonitor.addListener(new IStreamListener()
+            {
+                @Override
+                public void streamAppended(String text, IStreamMonitor monitor)
+                {
+                    outputBuffer.append(text);
+                }
+            });
+            stderrMonitor.addListener(new IStreamListener()
+            {
+                @Override
+                public void streamAppended(String text, IStreamMonitor monitor)
+                {
+                    errorBuffer.append(text);
+                }
+            });
+        }
+
+        String modeLabel = ILaunchManager.DEBUG_MODE.equals(mode) ? "debug" : "run";
+
+        if (timeout > 0)
+        {
+            // Wait for process to finish
+            boolean terminated = waitForTermination(launch, timeout);
+
+            var result = new StringBuilder();
+            result.append(subject).append(" launched in ").append(modeLabel).append(" mode.\n");
+
+            if (!terminated)
+            {
+                result.append("Note: Process still running after ").append(timeout).append("s timeout.\n");
+            }
+            else
+            {
+                // Get exit code
+                for (IProcess process : launch.getProcesses())
+                {
+                    try
+                    {
+                        result.append("Exit code: ").append(process.getExitValue()).append("\n");
+                    }
+                    catch (DebugException e)
+                    {
+                        result.append("Exit code: (unavailable)\n");
+                    }
+                }
+            }
+
+            if (outputBuffer.length() > 0)
+            {
+                result.append("\n--- stdout ---\n").append(truncateOutput(outputBuffer.toString(), 5000));
+            }
+            if (errorBuffer.length() > 0)
+            {
+                result.append("\n--- stderr ---\n").append(truncateOutput(errorBuffer.toString(), 2000));
+            }
+
+            return result.toString();
+        }
+
+        // Don't wait -- return immediately
+        return subject + " launched in " + modeLabel + " mode. " +
+               "Use stopApplication to terminate it, or getConsoleOutput to see its output.";
     }
 
     /**


### PR DESCRIPTION
## Summary

Two related improvements to the `eclipse-runner` MCP server's launch tools:

1. **New `launchConfiguration` tool** — launch an existing, *saved* launch configuration by name (run or debug), reusing its full setup: classpath, program/VM arguments, environment variables, working directory, and agent settings such as JRebel.
2. **New `listLaunchConfigurations` tool** — list saved launch configurations so a client can discover the exact name to pass to `launchConfiguration`.
3. **Fix: stop polluting the Run/Debug Configurations list** — `runJavaApplication`/`debugJavaApplication` no longer persist a throwaway `AssistAI-<Class>-<timestamp>` configuration on every launch.

## Motivation

`runJavaApplication`/`debugJavaApplication` build a launch configuration from scratch. That's fine for a bare main class, but it can't reproduce a configuration that depends on **environment variables, a JRebel/`-agentpath` agent, a custom classpath, or a working directory** — exactly what real-world "Run XYZ" configurations rely on. There was no way to ask the server to *just run my existing "Foo" configuration*.

Separately, every launch called `workingCopy.doSave()`, adding an `AssistAI-<Class>-<timestamp>` entry to the user's Run/Debug Configurations list. Cleanup only ran for **terminated, timed** runs, so background launches (`timeout=0`, the default for `debugJavaApplication`) leaked an entry every single time, and the list fills up with stale throwaway configs.

## Changes

**`JavaLaunchService`**
- Add `launchConfiguration(configurationName, mode, timeout)`: resolves a saved config by name (exact match, then case-insensitive), verifies `supportsMode`, and launches it — reusing everything the configuration defines.
- Add `listLaunchConfigurations()`: lists each config's name, type, and (for Java apps) project + main class.
- Launch the in-memory working copy **directly** instead of `doSave()`-ing it, so nothing is persisted to the configuration list. `stopApplication`/`listActiveLaunches`/`getStackTrace` still resolve name/main-type from the launch's in-memory configuration, so they're unaffected.
- Extract the shared launch + stream-capture + timeout/output logic into a private `executeLaunch(...)` used by both the from-scratch path and the new named-config path.

**`EclipseRunnerMcpServer`**
- Expose `launchConfiguration` and `listLaunchConfigurations` as `@Tool`s.

**Docs**
- README tool table; `eclipse-run` and `eclipse-debug` skills.

## Example

```
listLaunchConfigurations()
launchConfiguration(configurationName="Run Snapshot App No Data Compass Local", mode="debug", timeout="0")
```

## Testing

- `mvn -B clean package -DskipTests` → **BUILD SUCCESS**.
- The launch paths need a live workbench launch manager, so there are no unit tests for them (consistent with the other `eclipse-runner` services); validated by building and code review. With the `doSave()` removal, launching/relaunching via the run/debug tools no longer adds entries to the Run/Debug Configurations list.

## Notes
- Also normalized one pre-existing mojibake em-dash in a comment that happened to fall inside a touched method.
