### PR TITLE
Add openProject tool to import/open projects from directory path

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/EclipseIntegrationsMcpServer.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/EclipseIntegrationsMcpServer.java
@@ -185,6 +185,14 @@ public class EclipseIntegrationsMcpServer
         return projectService.listProjects();
     }
 
+    @Tool(name = "openProject", description = "Opens/imports a project into the Eclipse workspace from a directory path. If the directory contains a .project file, it imports the project as-is. If not, a basic .project is created and the directory is imported as a generic project.", type = "object")
+    public String openProject(
+            @ToolParam(name = "directoryPath", description = "The absolute filesystem path to the directory to open as a project") String directoryPath)
+    {
+        return projectService.openProject(directoryPath);
+    }
+
+
     @Tool(name = "getCurrentlyOpenedFile", description = "Gets information about the currently active file in the Eclipse editor.", type = "object")
     public String getCurrentlyOpenedFile()
     {

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/ProjectService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/ProjectService.java
@@ -3,6 +3,8 @@ package com.github.gradusnikov.eclipse.assistai.mcp.services;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -18,6 +20,8 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.e4.core.di.annotations.Creatable;
@@ -25,6 +29,7 @@ import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.core.resources.IProjectDescription;
 
 import com.github.gradusnikov.eclipse.assistai.resources.ResourceToolResult;
 import com.github.gradusnikov.eclipse.assistai.services.AiIgnoreService;
@@ -155,6 +160,52 @@ public class ProjectService {
         
         return result.toString();
     }
+
+    public String openProject(String directoryPath) {
+        try {
+            File directory = new File(directoryPath);
+            if (!directory.exists()) {
+                return "Error: Directory does not exist: " + directoryPath;
+            }
+            if (!directory.isDirectory()) {
+                return "Error: Path is not a directory: " + directoryPath;
+            }
+
+            IProgressMonitor monitor = new NullProgressMonitor();
+            File projectFile = new File(directory, ".project");
+
+            IProjectDescription description;
+            if (projectFile.exists()) {
+                org.eclipse.core.runtime.IPath projectFilePath = org.eclipse.core.runtime.Path.fromOSString(projectFile.getAbsolutePath());
+                description = ResourcesPlugin.getWorkspace().loadProjectDescription(projectFilePath);
+            } else {
+                String projectName = directory.getName();
+                description = ResourcesPlugin.getWorkspace().newProjectDescription(projectName);
+                org.eclipse.core.runtime.IPath locationPath = org.eclipse.core.runtime.Path.fromOSString(directory.getAbsolutePath());
+                description.setLocation(locationPath);
+            }
+
+            String projectName = description.getName();
+            IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+
+            if (project.exists()) {
+                if (!project.isOpen()) {
+                    project.open(monitor);
+                    return "Project '" + projectName + "' was already in workspace but closed. Opened successfully.";
+                }
+                return "Project '" + projectName + "' is already open in the workspace.";
+            }
+
+            project.create(description, monitor);
+            project.open(monitor);
+
+            return "Project '" + projectName + "' imported and opened successfully from: " + directoryPath;
+        } catch (CoreException e) {
+            logger.error(e.getMessage(), e);
+            return "Error opening project: " + e.getMessage();
+        }
+    }
+
     
     /**
      * Gets the file and folder structure of a specified project.

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/ProjectServiceTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/ProjectServiceTest.java
@@ -1,0 +1,132 @@
+package com.github.gradusnikov.eclipse.plugin.assistai.mcp.services;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.EclipseContextFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.util.tracker.ServiceTracker;
+
+import com.github.gradusnikov.eclipse.assistai.Activator;
+import com.github.gradusnikov.eclipse.assistai.mcp.services.ProjectService;
+import com.github.gradusnikov.eclipse.assistai.services.AiIgnoreService;
+
+public class ProjectServiceTest {
+
+    private ProjectService service;
+    private IWorkspaceRoot root;
+    private NullProgressMonitor monitor = new NullProgressMonitor();
+    private Path tempDir;
+
+    @BeforeEach
+    public void beforeEach() throws CoreException, IOException {
+        BundleContext bundleContext = FrameworkUtil.getBundle(ProjectServiceTest.class).getBundleContext();
+        ServiceTracker<IWorkspace, IWorkspace> workspaceTracker = new ServiceTracker<>(bundleContext, IWorkspace.class, null);
+        workspaceTracker.open();
+        IWorkspace workspace = workspaceTracker.getService();
+        root = workspace.getRoot();
+
+        IEclipseContext context = EclipseContextFactory.create();
+        context.set(ILog.class, Activator.getDefault().getLog());
+        context.set(AiIgnoreService.class, ContextInjectionFactory.make(AiIgnoreService.class, context));
+        service = ContextInjectionFactory.make(ProjectService.class, context);
+
+        tempDir = Files.createTempDirectory("projectServiceTest");
+    }
+
+    @AfterEach
+    public void afterEach() throws CoreException, IOException {
+        for (String name : new String[]{"ExistingProjectTest", "NoProjectFileTest"}) {
+            IProject project = root.getProject(name);
+            if (project.exists()) {
+                project.delete(false, true, monitor);
+            }
+        }
+        deleteRecursively(tempDir.toFile());
+    }
+
+    @Test
+    public void testOpenProjectWithExistingProjectFile() throws IOException {
+        Path projectDir = tempDir.resolve("ExistingProjectTest");
+        Files.createDirectories(projectDir);
+
+        String dotProject = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<projectDescription>\n"
+                + "    <name>ExistingProjectTest</name>\n"
+                + "    <comment></comment>\n"
+                + "    <projects></projects>\n"
+                + "    <buildSpec></buildSpec>\n"
+                + "    <natures></natures>\n"
+                + "</projectDescription>\n";
+        Files.writeString(projectDir.resolve(".project"), dotProject);
+
+        String result = service.openProject(projectDir.toAbsolutePath().toString());
+
+        assertTrue(result.contains("imported and opened successfully"), "Expected success message, got: " + result);
+
+        String projects = service.listProjects();
+        assertTrue(projects.contains("ExistingProjectTest"), "Project should appear in listProjects");
+    }
+
+    @Test
+    public void testOpenProjectWithoutProjectFile() throws IOException {
+        Path projectDir = tempDir.resolve("NoProjectFileTest");
+        Files.createDirectories(projectDir);
+        Files.writeString(projectDir.resolve("hello.txt"), "hello world");
+
+        assertFalse(Files.exists(projectDir.resolve(".project")), ".project should not exist before openProject");
+
+        String result = service.openProject(projectDir.toAbsolutePath().toString());
+
+        assertTrue(result.contains("imported and opened successfully"), "Expected success message, got: " + result);
+
+        String projects = service.listProjects();
+        assertTrue(projects.contains("NoProjectFileTest"), "Project should appear in listProjects");
+    }
+
+    @Test
+    public void testOpenProjectNonExistentDirectory() {
+        String result = service.openProject("/non/existent/path/xyz123");
+        assertTrue(result.contains("Directory does not exist"), "Expected error about non-existent directory, got: " + result);
+    }
+
+    @Test
+    public void testOpenProjectAlreadyOpen() throws IOException {
+        Path projectDir = tempDir.resolve("NoProjectFileTest");
+        Files.createDirectories(projectDir);
+
+        service.openProject(projectDir.toAbsolutePath().toString());
+        String result = service.openProject(projectDir.toAbsolutePath().toString());
+
+        assertTrue(result.contains("already open"), "Expected already open message, got: " + result);
+    }
+
+    private void deleteRecursively(File file) {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursively(child);
+                }
+            }
+        }
+        file.delete();
+    }
+}


### PR DESCRIPTION
Adds a new MCP tool 'openProject' that imports a project into the Eclipse workspace from a filesystem directory path. If the directory contains a .project file, it imports as-is. Otherwise, a basic project description is created and the directory is imported as a generic project.

- ProjectService.openProject(): business logic
- EclipseIntegrationsMcpServer: tool endpoint
- ProjectServiceTest: plugin tests covering both cases


i noticed this was handy to have because now and then ai would just generate a new (test) project but then it wouldn't be imported in eclipse and i needed todo that manually, so now it can just do that in one go, generate a full new eclipse project and then import it