### PR TITLE
Add plugin selection control to PDE test launcher

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/PDEMcpServer.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/PDEMcpServer.java
@@ -1,5 +1,8 @@
 package com.github.gradusnikov.eclipse.assistai.mcp.servers;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.e4.core.di.annotations.Creatable;
@@ -49,11 +52,15 @@ public class PDEMcpServer
     public String runJUnitPluginTests(
             @ToolParam(name = "projectName", description = "The exact Eclipse project name containing the plug-in test classes") String projectName,
             @ToolParam(name = "timeout", description = "Maximum time in seconds to wait for test completion (default: 60)", required = false) String timeout,
-            @ToolParam(name = "withCoverage", description = "If 'true', runs tests with code coverage (requires EclEmma/JaCoCo installed). Default: false", required = false) String withCoverage)
+            @ToolParam(name = "withCoverage", description = "If 'true', runs tests with code coverage (requires EclEmma/JaCoCo installed). Default: false", required = false) String withCoverage,
+            @ToolParam(name = "includeAllPlugins", description = "If 'true', launches with all workspace and target platform plug-ins (USE_DEFAULT mode). If 'false' (default), only includes the test plug-in and lets Eclipse auto-resolve required dependencies.", required = false) String includeAllPlugins,
+            @ToolParam(name = "additionalBundles", description = "Comma-separated list of additional bundle/plug-in symbolic names to include in the launch (only used when includeAllPlugins is false). Use this when auto-resolved dependencies are insufficient.", required = false) String additionalBundles)
     {
         int timeoutSeconds = Optional.ofNullable(timeout).map(Integer::parseInt).orElse(60);
         boolean coverage = Optional.ofNullable(withCoverage).map(Boolean::parseBoolean).orElse(false);
-        return pdeService.runJUnitPluginTests(projectName, timeoutSeconds, coverage);
+        boolean allPlugins = Optional.ofNullable(includeAllPlugins).map(Boolean::parseBoolean).orElse(false);
+        List<String> extras = parseAdditionalBundles(additionalBundles);
+        return pdeService.runJUnitPluginTests(projectName, timeoutSeconds, coverage, allPlugins, extras);
     }
 
     @Tool(name = "runJUnitPluginTestClass",
@@ -63,10 +70,26 @@ public class PDEMcpServer
             @ToolParam(name = "projectName", description = "The exact Eclipse project name containing the test class") String projectName,
             @ToolParam(name = "className", description = "The fully qualified class name (e.g., 'com.example.MyPluginTest')") String className,
             @ToolParam(name = "timeout", description = "Maximum time in seconds to wait for test completion (default: 60)", required = false) String timeout,
-            @ToolParam(name = "withCoverage", description = "If 'true', runs tests with code coverage (requires EclEmma/JaCoCo installed). Default: false", required = false) String withCoverage)
+            @ToolParam(name = "withCoverage", description = "If 'true', runs tests with code coverage (requires EclEmma/JaCoCo installed). Default: false", required = false) String withCoverage,
+            @ToolParam(name = "includeAllPlugins", description = "If 'true', launches with all workspace and target platform plug-ins (USE_DEFAULT mode). If 'false' (default), only includes the test plug-in and lets Eclipse auto-resolve required dependencies.", required = false) String includeAllPlugins,
+            @ToolParam(name = "additionalBundles", description = "Comma-separated list of additional bundle/plug-in symbolic names to include in the launch (only used when includeAllPlugins is false). Use this when auto-resolved dependencies are insufficient.", required = false) String additionalBundles)
     {
         int timeoutSeconds = Optional.ofNullable(timeout).map(Integer::parseInt).orElse(60);
         boolean coverage = Optional.ofNullable(withCoverage).map(Boolean::parseBoolean).orElse(false);
-        return pdeService.runJUnitPluginTestClass(projectName, className, timeoutSeconds, coverage);
+        boolean allPlugins = Optional.ofNullable(includeAllPlugins).map(Boolean::parseBoolean).orElse(false);
+        List<String> extras = parseAdditionalBundles(additionalBundles);
+        return pdeService.runJUnitPluginTestClass(projectName, className, timeoutSeconds, coverage, allPlugins, extras);
+    }
+
+    private List<String> parseAdditionalBundles(String additionalBundles)
+    {
+        if (additionalBundles == null || additionalBundles.isBlank())
+        {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(additionalBundles.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
     }
 }

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/PDEService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/PDEService.java
@@ -1,6 +1,9 @@
 package com.github.gradusnikov.eclipse.assistai.mcp.services;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -207,10 +210,16 @@ public class PDEService
      */
     public String runJUnitPluginTests( String projectName, Integer timeout )
     {
-        return runJUnitPluginTests( projectName, timeout, false );
+        return runJUnitPluginTests( projectName, timeout, false, false, List.of() );
     }
 
     public String runJUnitPluginTests( String projectName, Integer timeout, boolean withCoverage )
+    {
+        return runJUnitPluginTests( projectName, timeout, withCoverage, false, List.of() );
+    }
+
+    public String runJUnitPluginTests( String projectName, Integer timeout, boolean withCoverage,
+                                        boolean includeAllPlugins, List<String> additionalBundles )
     {
         Objects.requireNonNull( projectName, "Project name cannot be null" );
         if ( projectName.isEmpty() )
@@ -225,7 +234,7 @@ public class PDEService
         try
         {
             IJavaProject javaProject = getJavaProject( projectName );
-            return launchJUnitPluginTests( javaProject, null, null, timeout, withCoverage );
+            return launchJUnitPluginTests( javaProject, null, null, timeout, withCoverage, includeAllPlugins, additionalBundles );
         }
         catch ( IllegalArgumentException | CoreException e )
         {
@@ -238,10 +247,16 @@ public class PDEService
      */
     public String runJUnitPluginTestClass( String projectName, String className, Integer timeout )
     {
-        return runJUnitPluginTestClass( projectName, className, timeout, false );
+        return runJUnitPluginTestClass( projectName, className, timeout, false, false, List.of() );
     }
 
     public String runJUnitPluginTestClass( String projectName, String className, Integer timeout, boolean withCoverage )
+    {
+        return runJUnitPluginTestClass( projectName, className, timeout, withCoverage, false, List.of() );
+    }
+
+    public String runJUnitPluginTestClass( String projectName, String className, Integer timeout, boolean withCoverage,
+                                            boolean includeAllPlugins, List<String> additionalBundles )
     {
         Objects.requireNonNull( projectName, "Project name cannot be null" );
         Objects.requireNonNull( className, "Class name cannot be null" );
@@ -258,7 +273,7 @@ public class PDEService
             {
                 return "Error: Class '" + className + "' not found in project '" + projectName + "'.";
             }
-            return launchJUnitPluginTests( javaProject, null, type, timeout, withCoverage );
+            return launchJUnitPluginTests( javaProject, null, type, timeout, withCoverage, includeAllPlugins, additionalBundles );
         }
         catch ( IllegalArgumentException | CoreException e )
         {
@@ -271,7 +286,8 @@ public class PDEService
     // -------------------------------------------------------------------------
 
     private String launchJUnitPluginTests( IJavaProject javaProject, Object packageFragment,
-                                            IType testClass, int timeout, boolean withCoverage )
+                                            IType testClass, int timeout, boolean withCoverage,
+                                            boolean includeAllPlugins, List<String> additionalBundles )
     {
         CountDownLatch latch = new CountDownLatch( 1 );
         UnitTestService.TestRunResult[] testRunResults = new UnitTestService.TestRunResult[1];
@@ -365,6 +381,32 @@ public class PDEService
                 + javaProject.getElementName();
             workingCopy.setAttribute( IPDELauncherConstants.LOCATION, testWorkspace );
             workingCopy.setAttribute( IPDELauncherConstants.DOCLEAR, false );
+
+            if ( includeAllPlugins )
+            {
+                workingCopy.setAttribute( IPDELauncherConstants.USE_DEFAULT, true );
+                workingCopy.setAttribute( IPDELauncherConstants.AUTOMATIC_ADD, true );
+            }
+            else
+            {
+                workingCopy.setAttribute( IPDELauncherConstants.USE_DEFAULT, false );
+                workingCopy.setAttribute( IPDELauncherConstants.AUTOMATIC_ADD, false );
+                workingCopy.setAttribute( IPDELauncherConstants.INCLUDE_OPTIONAL, true );
+                workingCopy.setAttribute( IPDELauncherConstants.AUTOMATIC_INCLUDE_REQUIREMENTS, true );
+                workingCopy.setAttribute( IPDELauncherConstants.AUTOMATIC_VALIDATE, true );
+
+                Set<String> workspaceBundles = new TreeSet<>();
+                workspaceBundles.add( javaProject.getElementName() + "@default:false" );
+                if ( additionalBundles != null )
+                {
+                    for ( String bundle : additionalBundles )
+                    {
+                        workspaceBundles.add( bundle + "@default:false" );
+                    }
+                }
+                workingCopy.setAttribute( IPDELauncherConstants.SELECTED_WORKSPACE_BUNDLES, workspaceBundles );
+                workingCopy.setAttribute( IPDELauncherConstants.SELECTED_TARGET_BUNDLES, new TreeSet<String>() );
+            }
 
             ILaunchConfiguration configuration = workingCopy.doSave();
 

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/servers/PDEMcpServerTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/servers/PDEMcpServerTest.java
@@ -110,12 +110,134 @@ public class PDEMcpServerTest
     {
         try
         {
-            // Non-existent project â will get an error string back, not an exception
-            String result = server.runJUnitPluginTests( "NonExistentProject_XYZ", null, null );
+            String result = server.runJUnitPluginTests( "NonExistentProject_XYZ", null, null, null, null );
             assertNotNull( result );
             assertTrue( result.startsWith( "Error" ),
                 "Expected error for non-existent project, got: " + result );
         }
+        catch ( IllegalStateException e )
+        {
+            assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    @Test
+    public void testRunJUnitPluginTests_explicitTimeout_parsed()
+    {
+        try
+        {
+            String result = server.runJUnitPluginTests( "NonExistentProject_XYZ", "30", null, null, null );
+            assertNotNull( result );
+            assertTrue( result.startsWith( "Error" ),
+                "Expected error for non-existent project, got: " + result );
+        }
+        catch ( IllegalStateException e )
+        {
+            assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    @Test
+    public void testRunJUnitPluginTests_includeAllPluginsTrue()
+    {
+        try
+        {
+            String result = server.runJUnitPluginTests( "NonExistentProject_XYZ", "10", null, "true", null );
+            assertNotNull( result );
+            assertTrue( result.startsWith( "Error" ),
+                "Expected error for non-existent project, got: " + result );
+        }
+        catch ( IllegalStateException e )
+        {
+            assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    @Test
+    public void testRunJUnitPluginTests_includeAllPluginsFalse()
+    {
+        try
+        {
+            String result = server.runJUnitPluginTests( "NonExistentProject_XYZ", "10", null, "false", null );
+            assertNotNull( result );
+            assertTrue( result.startsWith( "Error" ),
+                "Expected error for non-existent project, got: " + result );
+        }
+        catch ( IllegalStateException e )
+        {
+            assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    @Test
+    public void testRunJUnitPluginTests_withAdditionalBundles()
+    {
+        try
+        {
+            String result = server.runJUnitPluginTests(
+                "NonExistentProject_XYZ", "10", null, "false", "org.eclipse.core.runtime,org.eclipse.ui" );
+            assertNotNull( result );
+            assertTrue( result.startsWith( "Error" ),
+                "Expected error for non-existent project, got: " + result );
+        }
+        catch ( IllegalStateException e )
+        {
+            assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    @Test
+    public void testRunJUnitPluginTestClass_nullTimeout_usesDefault()
+    {
+        try
+        {
+            String result = server.runJUnitPluginTestClass(
+                "NonExistentProject_XYZ", "com.example.MyTest", null, null, null, null );
+            assertNotNull( result );
+            assertTrue( result.startsWith( "Error" ),
+                "Expected error for non-existent project, got: " + result );
+        }
+        catch ( IllegalStateException e )
+        {
+            assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    @Test
+    public void testRunJUnitPluginTestClass_includeAllPluginsTrue()
+    {
+        try
+        {
+            String result = server.runJUnitPluginTestClass(
+                "NonExistentProject_XYZ", "com.example.MyTest", "10", null, "true", null );
+            assertNotNull( result );
+            assertTrue( result.startsWith( "Error" ),
+                "Expected error for non-existent project, got: " + result );
+        }
+        catch ( IllegalStateException e )
+        {
+            assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );
+        }
+    }
+
+    @Test
+    public void testRunJUnitPluginTestClass_withAdditionalBundles()
+    {
+        try
+        {
+            String result = server.runJUnitPluginTestClass(
+                "NonExistentProject_XYZ", "com.example.MyTest", "10", null, "false",
+                "org.eclipse.core.runtime, org.eclipse.ui" );
+            assertNotNull( result );
+            assertTrue( result.startsWith( "Error" ),
+                "Expected error for non-existent project, got: " + result );
+        }
+        catch ( IllegalStateException e )
+        {
+            assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );
+        }
+    }
+}
         catch ( IllegalStateException e )
         {
             assumeTrue( false, "Skipping: workspace not available (" + e.getMessage() + ")" );

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/PDEServicePluginTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/plugin/assistai/mcp/services/PDEServicePluginTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -397,6 +398,113 @@ public class PDEServicePluginTest
             "Skipping: PDE launcher not available or project has errors (" + result + ")" );
         assertTrue( !result.contains( "does not exist" ),
             "Got 'does not exist' error - container format is wrong: " + result );
+        assertTrue( result.contains( "Passed" ) || result.contains( "passed" )
+            || result.contains( "timed out" ),
+            "Expected test results or timeout, got: " + result );
+    }
+
+    // -------------------------------------------------------------------------
+    // includeAllPlugins parameter
+    // -------------------------------------------------------------------------
+
+    @Test
+    @Order( 22 )
+    public void testRunJUnitPluginTests_includeAllPlugins_nonExistentProject()
+    {
+        String result = service.runJUnitPluginTests( "NonExistentProject_PDEPlugin", 10, false, true, List.of() );
+        assertNotNull( result );
+        assertTrue( result.startsWith( "Error" ),
+            "Expected error for non-existent project, got: " + result );
+    }
+
+    @Test
+    @Order( 23 )
+    public void testRunJUnitPluginTests_selectedPlugins_nonExistentProject()
+    {
+        String result = service.runJUnitPluginTests( "NonExistentProject_PDEPlugin", 10, false, false, List.of() );
+        assertNotNull( result );
+        assertTrue( result.startsWith( "Error" ),
+            "Expected error for non-existent project, got: " + result );
+    }
+
+    @Test
+    @Order( 24 )
+    public void testRunJUnitPluginTests_withAdditionalBundles_nonExistentProject()
+    {
+        String result = service.runJUnitPluginTests(
+            "NonExistentProject_PDEPlugin", 10, false, false,
+            List.of( "org.eclipse.core.runtime", "org.eclipse.ui" ) );
+        assertNotNull( result );
+        assertTrue( result.startsWith( "Error" ),
+            "Expected error for non-existent project, got: " + result );
+    }
+
+    @Test
+    @Order( 25 )
+    public void testRunJUnitPluginTestClass_includeAllPlugins_nonExistentProject()
+    {
+        String result = service.runJUnitPluginTestClass(
+            "NonExistentProject_PDEPlugin", "com.example.MyTest", 10, false, true, List.of() );
+        assertNotNull( result );
+        assertTrue( result.startsWith( "Error" ),
+            "Expected error for non-existent project, got: " + result );
+    }
+
+    @Test
+    @Order( 26 )
+    public void testRunJUnitPluginTestClass_withAdditionalBundles_nonExistentProject()
+    {
+        String result = service.runJUnitPluginTestClass(
+            "NonExistentProject_PDEPlugin", "com.example.MyTest", 10, false, false,
+            List.of( "org.eclipse.core.runtime" ) );
+        assertNotNull( result );
+        assertTrue( result.startsWith( "Error" ),
+            "Expected error for non-existent project, got: " + result );
+    }
+
+    // -------------------------------------------------------------------------
+    // Integration: run with selected plugins mode on real project
+    // -------------------------------------------------------------------------
+
+    @Test
+    @Order( 30 )
+    public void testRunJUnitPluginTestClass_selectedPluginsMode_realProject()
+    {
+        String result = service.runJUnitPluginTestClass(
+            TEST_PLUGIN_PROJECT,
+            "com.example.pdetest.SimplePluginTest",
+            120, false, false, List.of() );
+        System.out.println( "runJUnitPluginTestClass (selected) result: " + result );
+        assumeTrue( !result.contains( "Error" ),
+            "Skipping: PDE launcher not available or project has errors (" + result + ")" );
+        assertTrue( result.contains( "Passed" ) || result.contains( "passed" ),
+            "Expected passing tests in result, got: " + result );
+    }
+
+    @Test
+    @Order( 31 )
+    public void testRunJUnitPluginTestClass_allPluginsMode_realProject()
+    {
+        String result = service.runJUnitPluginTestClass(
+            TEST_PLUGIN_PROJECT,
+            "com.example.pdetest.SimplePluginTest",
+            120, false, true, List.of() );
+        System.out.println( "runJUnitPluginTestClass (all) result: " + result );
+        assumeTrue( !result.contains( "Error" ),
+            "Skipping: PDE launcher not available or project has errors (" + result + ")" );
+        assertTrue( result.contains( "Passed" ) || result.contains( "passed" ),
+            "Expected passing tests in result, got: " + result );
+    }
+
+    @Test
+    @Order( 32 )
+    public void testRunJUnitPluginTests_selectedPluginsMode_realProject()
+    {
+        String result = service.runJUnitPluginTests(
+            TEST_PLUGIN_PROJECT, 120, false, false, List.of() );
+        System.out.println( "runJUnitPluginTests (selected) result: " + result );
+        assumeTrue( !result.contains( "Error" ),
+            "Skipping: PDE launcher not available or project has errors (" + result + ")" );
         assertTrue( result.contains( "Passed" ) || result.contains( "passed" )
             || result.contains( "timed out" ),
             "Expected test results or timeout, got: " + result );


### PR DESCRIPTION
i would like to have a bit more options when launching a pde plugin test
because by default (if you would do it by eclipse itself) then it is more in the "select the test plugin and all the required plugins" not "all plugins everywhere". That last part can lead to weird stuff and long bundle resolving because eclipse has a lot of conflicting plugins.
So this pull makes the way eclipse does it default, but still with a boolean you can say "include all"
but besides that when we do the default eclipse one you can also add a a bundle list of what should also be included.. (So you can add a few more, you can tell ai if you run this class as a plugin test don't include all the plugins but do add these. xxxx. 

- Add includeAllPlugins parameter (default false) to choose between launching with all plugins (USE_DEFAULT) or selected plugins only
- Add additionalBundles parameter for specifying extra bundles when using selected plugins mode
- Default behavior now selects only the test plugin and lets Eclipse auto-resolve required dependencies (AUTOMATIC_INCLUDE_REQUIREMENTS)
- Add tests for new parameters in PDEMcpServerTest and PDEServicePluginTest