### PR TITLE
Fixed 129: UTF-8 encoding for MCP HTTP transport.

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/http/HttpMcpServerRegistry.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/http/HttpMcpServerRegistry.java
@@ -215,6 +215,8 @@ public class HttpMcpServerRegistry
             var stored = mcpServerRepository.listStoredServers();
             initializeBuiltInServers( context, stored, builtin );
 
+            context.getPipeline().addValve( new JsonUtf8EncodingValve() );
+
             String token = httpServerPreferncesProvider.get().token();
             if ( token != null && !token.isBlank() )
             {

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/http/JsonUtf8EncodingValve.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/http/JsonUtf8EncodingValve.java
@@ -1,0 +1,28 @@
+package com.github.gradusnikov.eclipse.assistai.mcp.http;
+
+import java.io.IOException;
+
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.catalina.valves.ValveBase;
+
+import jakarta.servlet.ServletException;
+
+public class JsonUtf8EncodingValve extends ValveBase
+{
+    public JsonUtf8EncodingValve()
+    {
+        setAsyncSupported( true );
+    }
+
+    @Override
+    public void invoke( Request request, Response response ) throws IOException, ServletException
+    {
+        String contentType = request.getContentType();
+        if ( contentType != null && contentType.contains( "application/json" ) && request.getCharacterEncoding() == null )
+        {
+            request.setCharacterEncoding( "UTF-8" );
+        }
+        getNext().invoke( request, response );
+    }
+}


### PR DESCRIPTION
Add JsonUtf8EncodingValve to force UTF-8 character encoding on incoming JSON requests. Tomcat defaults to ISO-8859-1 when the Content-Type header
has no explicit charset, causing multi-byte Unicode characters (e.g. em-dashes)
to be corrupted (mojibake) when written to workspace files via MCP tools.

The valve runs early in the pipeline and sets UTF-8 only when Content-Type
is application/json and no charset is already specified. [AI]