### PR TITLE
Fix OpenAI's new function_call chunks

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/OpenAIStreamJavaHttpClient.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/network/clients/OpenAIStreamJavaHttpClient.java
@@ -300,13 +300,13 @@ public class OpenAIStreamJavaHttpClient extends AbstractLanguageModelClient {
 										if (functionNode == null || functionNode.isNull()) {
 											continue;
 										}
-										if (functionNode.has("name")) {
+										if (functionNode.has("name") && !functionNode.get("name").asText().isEmpty()) {
 											var toolId = toolCall.has("id") ? toolCall.get("id").asText() : "";
 											publisher.submit(new Incoming(Incoming.Type.FUNCTION_CALL, String.format(
 													"\"function_call\" : { \n \"id\": \"%s\",\n \"name\": \"%s\",\n \"arguments\" :",
 													toolId, functionNode.get("name").asText())));
 										}
-										if (functionNode.has("arguments")) {
+										if (functionNode.has("arguments") && !functionNode.get("arguments").asText().isEmpty()) {
 											publisher.submit(new Incoming(Incoming.Type.FUNCTION_CALL,
 													functionNode.get("arguments").asText()));
 										}


### PR DESCRIPTION
As OpenAI's streaming api responsed new format of function call, the IDE could throw exceptions.

Old response:
chunk1: function:{"name":"foo","arguments":""}
chunk2: function:{"arguments":"{\"a\":1}"}

New response (gpt-5.5):
chunk1: function:{"name":"foo","arguments":""}
chunk2: function:{"name":"","arguments":"{\"a\":1}"}  // name is null but it exists

So code in OpenAIStreamJavaHttpClient.java has to change.