### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #136)

### DIFF
--- a/.claude/skills/eclipse-analyze/SKILL.md
+++ b/.claude/skills/eclipse-analyze/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: eclipse-analyze
 description: Analyze Java code using Eclipse JDT tools — type hierarchy, find references, call hierarchy, compilation errors, quick fixes, and import suggestions. Use this to understand code structure before making changes.
-argument-hint: [class or element to analyze]
+argument-hint: "[class or element to analyze]"
 allowed-tools: mcp__eclipse-ide__getClassOutline, mcp__eclipse-ide__getMethodSource, mcp__eclipse-ide__getFilteredSource, mcp__eclipse-ide__getTypeHierarchy, mcp__eclipse-ide__findReferences, mcp__eclipse-ide__getMethodCallHierarchy, mcp__eclipse-ide__getCompilationErrors, mcp__eclipse-ide__getQuickFixes, mcp__eclipse-ide__getImportSuggestions, mcp__eclipse-ide__getJavaDoc, mcp__eclipse-ide__getSource, mcp__eclipse-ide__getProjectLayout, mcp__eclipse-ide__getProjectProperties, mcp__eclipse-ide__readProjectResource, mcp__eclipse-ide__listProjects, mcp__eclipse-ide__getCurrentlyOpenedFile, mcp__eclipse-ide__getEditorSelection, mcp__eclipse-ide__fileSearch, mcp__eclipse-ide__fileSearchRegExp, mcp__eclipse-ide__findFiles, mcp__eclipse-ide__getProjectDependencies
 ---
 

--- a/.claude/skills/eclipse-debug/SKILL.md
+++ b/.claude/skills/eclipse-debug/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: eclipse-debug
 description: Debug Java applications in Eclipse — set breakpoints, launch in debug mode, step through code, inspect stack traces, evaluate expressions, and hot-swap code changes.
-argument-hint: [project] [main class]
+argument-hint: "[project] [main class]"
 allowed-tools: mcp__eclipse-runner__debugJavaApplication, mcp__eclipse-runner__launchConfiguration, mcp__eclipse-runner__listLaunchConfigurations, mcp__eclipse-runner__stopApplication, mcp__eclipse-runner__listActiveLaunches, mcp__eclipse-runner__toggleBreakpoint, mcp__eclipse-runner__setConditionalBreakpoint, mcp__eclipse-runner__listBreakpoints, mcp__eclipse-runner__removeAllBreakpoints, mcp__eclipse-runner__getStackTrace, mcp__eclipse-runner__evaluateExpression, mcp__eclipse-runner__resumeDebug, mcp__eclipse-runner__stepOver, mcp__eclipse-runner__stepInto, mcp__eclipse-runner__stepReturn, mcp__eclipse-runner__hotCodeReplace, mcp__eclipse-ide__getConsoleOutput
 ---
 

--- a/.claude/skills/eclipse-edit/SKILL.md
+++ b/.claude/skills/eclipse-edit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: eclipse-edit
 description: Edit files in Eclipse projects using MCP tools. Use this when modifying code in Eclipse workspace projects — it keeps Eclipse editors in sync, triggers incremental compilation, and provides undo via local history.
-argument-hint: [description of changes]
+argument-hint: "[description of changes]"
 allowed-tools: mcp__eclipse-coder__applyPatch, mcp__eclipse-coder__replaceString, mcp__eclipse-coder__insertIntoFile, mcp__eclipse-coder__createFile, mcp__eclipse-coder__deleteFile, mcp__eclipse-coder__deleteLinesInFile, mcp__eclipse-coder__replaceFileContent, mcp__eclipse-coder__formatFile, mcp__eclipse-coder__organizeImports, mcp__eclipse-coder__organizeImportsInPackage, mcp__eclipse-coder__undoEdit, mcp__eclipse-coder__renameFile, mcp__eclipse-coder__createDirectories, mcp__eclipse-coder__moveResource, mcp__eclipse-coder__refactorRenameJavaType, mcp__eclipse-coder__refactorMoveJavaType, mcp__eclipse-coder__refactorRenamePackage, mcp__eclipse-ide__getCompilationErrors, mcp__eclipse-ide__getProjectLayout, mcp__eclipse-ide__readProjectResource, mcp__eclipse-ide__getClassOutline, mcp__eclipse-ide__getMethodSource, mcp__eclipse-ide__getFilteredSource, mcp__eclipse-ide__getSource
 ---
 

--- a/.claude/skills/eclipse-run/SKILL.md
+++ b/.claude/skills/eclipse-run/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: eclipse-run
 description: Launch and stop Java applications in Eclipse. Run with program/VM arguments, capture stdout/stderr, or launch in background.
-argument-hint: [project] [main class]
+argument-hint: "[project] [main class]"
 allowed-tools: mcp__eclipse-runner__runJavaApplication, mcp__eclipse-runner__launchConfiguration, mcp__eclipse-runner__listLaunchConfigurations, mcp__eclipse-runner__stopApplication, mcp__eclipse-runner__listActiveLaunches, mcp__eclipse-ide__getConsoleOutput
 ---
 

--- a/.claude/skills/eclipse-test/SKILL.md
+++ b/.claude/skills/eclipse-test/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: eclipse-test
 description: Run JUnit tests in Eclipse projects — all tests, by package, by class, or individual test methods. Also build Maven projects.
-argument-hint: [project] [class or package]
+argument-hint: "[project] [class or package]"
 allowed-tools: mcp__eclipse-ide__runAllTests, mcp__eclipse-ide__runPackageTests, mcp__eclipse-ide__runClassTests, mcp__eclipse-ide__runTestMethod, mcp__eclipse-ide__findTestClasses, mcp__eclipse-ide__runMavenBuild, mcp__eclipse-ide__getConsoleOutput, mcp__eclipse-ide__getEffectivePom, mcp__eclipse-ide__listMavenProjects, mcp__eclipse-ide__getProjectDependencies, mcp__eclipse-ide__getCompilationErrors
 ---
 


### PR DESCRIPTION
Closes #136.

## Summary

Purely mechanical single-character transform to 5 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (5)

- `.claude/skills/eclipse-run/SKILL.md`
- `.claude/skills/eclipse-edit/SKILL.md`
- `.claude/skills/eclipse-analyze/SKILL.md`
- `.claude/skills/eclipse-debug/SKILL.md`
- `.claude/skills/eclipse-test/SKILL.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
