### PR TITLE
Fix a NPE bug on reading projects

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/jobs/ExecuteFunctionCallJob.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/jobs/ExecuteFunctionCallJob.java
@@ -277,13 +277,15 @@ public class ExecuteFunctionCallJob extends Job
     private String cacheStructuredRead( Object structuredContent )
     {
         ResourceReadResult read = ResourceReadResult.fromStructuredContent( structuredContent );
-        if ( read == null || !read.isCacheable() )
+        if ( read == null || !read.isCacheable()
+                || read.projectName() == null || read.projectName().isBlank()
+                || read.filePath() == null || read.filePath().isBlank() )
         {
             return null;
         }
 
         IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject( read.projectName() );
-        if ( project == null || !project.exists() )
+        if ( !project.exists() )
         {
             return null;
         }


### PR DESCRIPTION
It usually happens when using *getSource()*

java.lang.NullPointerException: Cannot invoke "Object.hashCode()" because "key" is null
at java.base/java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936)
at org.eclipse.core.internal.resources.WorkspaceRoot.getProject(WorkspaceRoot.java:163)
at com.github.gradusnikov.eclipse.assistai.jobs.ExecuteFunctionCallJob.cacheStructuredRead(ExecuteFunctionCallJob.java:285)
at com.github.gradusnikov.eclipse.assistai.jobs.ExecuteFunctionCallJob.createFunctionResultMessage(ExecuteFunctionCallJob.java:212)
at com.github.gradusnikov.eclipse.assistai.jobs.ExecuteFunctionCallJob.handleFunctionResult(ExecuteFunctionCallJob.java:172)
at com.github.gradusnikov.eclipse.assistai.jobs.ExecuteFunctionCallJob.executeFunctionCall(ExecuteFunctionCallJob.java:147)
at com.github.gradusnikov.eclipse.assistai.jobs.ExecuteFunctionCallJob.run(ExecuteFunctionCallJob.java:86)
at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)