### PR TITLE
Add code discovery MCP tools for codebase orientation

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/docs/mcp-api.md
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/docs/mcp-api.md
@@ -45,7 +45,7 @@ a `status` a caller can branch on, and `diagnostics` carrying a coded
 | [eclipse-coder](#eclipse-coder) | 21 |
 | [eclipse-context](#eclipse-context) | 7 |
 | [eclipse-git](#eclipse-git) | 15 |
-| [eclipse-ide](#eclipse-ide) | 35 |
+| [eclipse-ide](#eclipse-ide) | 39 |
 | [eclipse-pde](#eclipse-pde) | 6 |
 | [eclipse-runner](#eclipse-runner) | 17 |
 | [memory](#memory) | 2 |
@@ -803,6 +803,17 @@ Returns the source of specific method(s) of one class. Accepts comma-separated m
 
 **Returns** [`MethodSourceResponse`](#methodsourceresponse)
 
+### `getPackageSummary` *(long)*
+
+Returns a table-of-contents for a Java package: every type's name, kind (class/interface/enum/record), Javadoc first sentence, method count, field count, and implemented interfaces — all in one call. Use this after searchTypes or getWorkspaceOverview identifies a relevant package, to understand what the package contains without reading each file individually. The Javadoc summaries help you decide which types are relevant to the user's request. Follow up with getClassOutline or getMethodSource on specific types of interest.
+
+| Parameter | | Description |
+|---|---|---|
+| `packageName` | \* | Fully qualified package name (e.g. 'com.example.payment', 'org.acme.auth.service') |
+| `projectName` |  | Optional project name to narrow the search. Useful in multi-project workspaces. |
+
+**Returns** [`PackageSummaryResponse`](#packagesummaryresponse)
+
 ### `getProjectDependencies` *(long)*
 
 Lists the dependencies one project's pom declares. These come from the Maven project model - what the pom declares after inheritance from its parent - and not from the resolved transitive graph; for the fully resolved form use getEffectivePom. version is null when the pom does not state one here, which is the ordinary case for a dependency managed by a parent's dependencyManagement. scope is 'compile' when the pom omits it, the default Maven itself applies.
@@ -854,6 +865,17 @@ Retrieves the type hierarchy of a Java class or interface as three separate list
 | `fullyQualifiedClassName` | \* | The fully qualified name of the class (e.g., 'com.example.MyClass') |
 
 **Returns** [`TypeHierarchyResponse`](#typehierarchyresponse)
+
+### `getWorkspaceOverview` *(long)*
+
+Returns a high-level architectural map of the workspace: all projects, their source packages, and the type names in each package. Use this as the FIRST tool when orienting in an unfamiliar codebase or when you need to understand the overall project structure before making changes. Typical workflow: getWorkspaceOverview -> identify relevant packages -> getPackageSummary on those packages -> getClassOutline/getMethodSource on specific types. For large workspaces, use projectFilter to focus on specific projects.
+
+| Parameter | | Description |
+|---|---|---|
+| `projectFilter` |  | Optional substring to filter projects by name (e.g. 'payment' shows only payment-related projects, 'service' shows service projects). Leave empty to see all projects. |
+| `maxPackagesPerProject` |  | Maximum number of packages to show per project (default: 50). Lower this for large projects to get a quick overview. |
+
+**Returns** [`WorkspaceOverviewResponse`](#workspaceoverviewresponse)
 
 ### `listMavenProjects`
 
@@ -942,6 +964,29 @@ Search and replace across multiple files in the workspace using Eclipse's text s
 | `fileNamePatterns` |  | Optional comma-separated file name patterns (e.g. "*.java,*.xml"). If omitted, all files are searched. |
 
 **Returns** [`SearchReplaceResponse`](#searchreplaceresponse)
+
+### `searchMethods` *(long)*
+
+Searches for methods by name pattern across the entire workspace. Use this when you know (or can guess) a method name but don't know which class contains it. For example, if a user says 'fix the error handling', search for '*error*' or 'handle*' to find relevant methods. Supports wildcards (* and ?), CamelCase matching, and prefix matching. Optionally filter by declaring type to narrow results. Returns the method name, declaring class, package, parameter types, and return type. After finding a method, use getMethodSource to read its implementation.
+
+| Parameter | | Description |
+|---|---|---|
+| `pattern` | \* | Method name pattern. Supports: wildcards (handle*Error, get*, *Payment, process*), CamelCase (pP -> processPayment — requires 2+ uppercase letters), or prefix (handle -> handleError, handleTimeout, ...). Note: CamelCase and prefix patterns are case-sensitive; use wildcards (*foo*) for case-insensitive matching. |
+| `declaringTypePattern` |  | Optional pattern to filter by declaring type name (e.g. '*Service', 'Payment*'). Useful when the method name is common (e.g. 'get*') and you want to narrow to specific classes. |
+| `maxResults` |  | Maximum number of results to return (default: 100) |
+
+**Returns** [`MethodSearchResponse`](#methodsearchresponse)
+
+### `searchTypes` *(long)*
+
+Searches for Java types (classes, interfaces, enums, records, annotations) by name pattern. This is the primary discovery tool — use it FIRST when a user mentions a concept (e.g. 'payment handling', 'authentication') and you need to find which classes implement it. Supports wildcards (* and ?), CamelCase matching (e.g. 'PS' finds 'PaymentService'), and prefix matching. Prefer this over fileSearch for finding types: it searches the JDT index (instant) rather than file contents, and supports CamelCase patterns that text search cannot. After finding types, use getClassOutline or getPackageSummary to understand them, then getMethodSource to read specific methods.
+
+| Parameter | | Description |
+|---|---|---|
+| `pattern` | \* | Type name pattern. Supports: wildcards (*Payment*, *Service, Error*), CamelCase (PS -> PaymentService, TxH -> TransactionHandler, CC -> CreditCard), prefix (Payment -> PaymentService, PaymentProcessor, ...), or package-qualified (com.example.*Service). Tips: try multiple patterns for a concept — e.g. for 'payment' try '*Payment*', '*Billing*', '*Transaction*'. |
+| `maxResults` |  | Maximum number of results to return (default: 100) |
+
+**Returns** [`TypeSearchResponse`](#typesearchresponse)
 
 ### `updateMavenProject` *(long)*
 
@@ -1683,6 +1728,16 @@ Reads the content of the given web page and returns it as markdown, together wit
 | `notFound` | `String`[] |
 | `diagnostics` | [`Diagnostic`](#diagnostic)[] |
 
+### `PackageSummaryResponse`
+
+| Field | Type |
+|---|---|
+| `packageName` | `String` |
+| `projectName` | `String` |
+| `totalTypes` | `int` |
+| `types` | [`PackageSummaryResponseTypeSummary`](#packagesummaryresponsetypesummary)[] |
+| `summaryText` | `String` |
+
 ### `MavenDependenciesResponse`
 
 | Field | Type |
@@ -1728,6 +1783,16 @@ Reads the content of the given web page and returns it as markdown, together wit
 | `superclasses` | [`TypeHierarchyResponseHierarchyType`](#typehierarchyresponsehierarchytype)[] |
 | `interfaces` | [`TypeHierarchyResponseHierarchyType`](#typehierarchyresponsehierarchytype)[] |
 | `subtypes` | [`TypeHierarchyResponseHierarchyType`](#typehierarchyresponsehierarchytype)[] |
+| `summaryText` | `String` |
+
+### `WorkspaceOverviewResponse`
+
+| Field | Type |
+|---|---|
+| `totalProjects` | `int` |
+| `totalPackages` | `int` |
+| `totalTypes` | `int` |
+| `projects` | [`WorkspaceOverviewResponseProjectOverview`](#workspaceoverviewresponseprojectoverview)[] |
 | `summaryText` | `String` |
 
 ### `MavenProjectListResponse`
@@ -1791,6 +1856,26 @@ Reads the content of the given web page and returns it as markdown, together wit
 | `totalMatches` | `int` |
 | `totalReplacements` | `int` |
 | `files` | [`SearchReplaceResponseFileReplacement`](#searchreplaceresponsefilereplacement)[] |
+| `summaryText` | `String` |
+
+### `MethodSearchResponse`
+
+| Field | Type |
+|---|---|
+| `pattern` | `String` |
+| `totalMatches` | `int` |
+| `methods` | [`MethodSearchResponseMethodMatch`](#methodsearchresponsemethodmatch)[] |
+| `truncated` | `boolean` |
+| `summaryText` | `String` |
+
+### `TypeSearchResponse`
+
+| Field | Type |
+|---|---|
+| `pattern` | `String` |
+| `totalMatches` | `int` |
+| `types` | [`TypeSearchResponseTypeMatch`](#typesearchresponsetypematch)[] |
+| `truncated` | `boolean` |
 | `summaryText` | `String` |
 
 ### `ActiveTargetResponse`
@@ -2273,6 +2358,17 @@ Reads the content of the given web page and returns it as markdown, together wit
 | `range` | [`ContentRange`](#contentrange) |
 | `source` | `String` |
 
+### `PackageSummaryResponseTypeSummary`
+
+| Field | Type |
+|---|---|
+| `simpleName` | `String` |
+| `typeKind` | `String` |
+| `javadocSummary` | `String` |
+| `methodCount` | `int` |
+| `fieldCount` | `int` |
+| `superInterfaces` | `String`[] |
+
 ### `MavenDependenciesResponseMavenDependency`
 
 | Field | Type |
@@ -2323,6 +2419,15 @@ Reads the content of the given web page and returns it as markdown, together wit
 | `fullyQualifiedName` | `String` |
 | `projectName` | `String` |
 | `filePath` | `String` |
+
+### `WorkspaceOverviewResponseProjectOverview`
+
+| Field | Type |
+|---|---|
+| `projectName` | `String` |
+| `packageCount` | `int` |
+| `typeCount` | `int` |
+| `packages` | [`WorkspaceOverviewResponsePackageOverview`](#workspaceoverviewresponsepackageoverview)[] |
 
 ### `MavenProjectListResponseMavenProject`
 
@@ -2407,6 +2512,27 @@ Reads the content of the given web page and returns it as markdown, together wit
 | `filePath` | `String` |
 | `matchesFound` | `int` |
 | `replacementsMade` | `int` |
+
+### `MethodSearchResponseMethodMatch`
+
+| Field | Type |
+|---|---|
+| `methodName` | `String` |
+| `declaringType` | `String` |
+| `packageName` | `String` |
+| `projectName` | `String` |
+| `returnType` | `String` |
+| `parameterTypes` | `String`[] |
+
+### `TypeSearchResponseTypeMatch`
+
+| Field | Type |
+|---|---|
+| `fullyQualifiedName` | `String` |
+| `simpleName` | `String` |
+| `packageName` | `String` |
+| `projectName` | `String` |
+| `typeKind` | `String` |
 
 ### `ActiveTargetResponseTargetStatus`
 
@@ -2561,6 +2687,14 @@ Reads the content of the given web page and returns it as markdown, together wit
 ### `ProjectLayoutResponseNodeType`
 
 `PROJECT` \| `FOLDER` \| `FILE`
+
+### `WorkspaceOverviewResponsePackageOverview`
+
+| Field | Type |
+|---|---|
+| `packageName` | `String` |
+| `typeCount` | `int` |
+| `typeNames` | `String`[] |
 
 ### `McpSchemaRole`
 

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/results/MethodSearchResponse.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/results/MethodSearchResponse.java
@@ -1,0 +1,40 @@
+package com.github.gradusnikov.eclipse.assistai.mcp.results;
+
+import java.util.List;
+
+public record MethodSearchResponse(
+    String pattern,
+    int totalMatches,
+    List<MethodMatch> methods,
+    boolean truncated,
+    String summaryText
+)
+{
+    public record MethodMatch(
+        String methodName,
+        String declaringType,
+        String packageName,
+        String projectName,
+        String returnType,
+        List<String> parameterTypes
+    )
+    {
+    }
+
+    public static MethodSearchResponse of( String pattern, List<MethodMatch> methods, int limit )
+    {
+        boolean truncated = limit > 0 && methods.size() > limit;
+        List<MethodMatch> shown = truncated ? methods.subList( 0, limit ) : methods;
+        return new MethodSearchResponse( pattern, methods.size(), shown, truncated, summarize( methods.size(), truncated, shown.size() ) );
+    }
+
+    private static String summarize( int total, boolean truncated, int shown )
+    {
+        if ( total == 0 )
+        {
+            return "No methods found.";
+        }
+        String summary = total + ( total == 1 ? " method found." : " methods found." );
+        return truncated ? summary + " Showing the first " + shown + "." : summary;
+    }
+}

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/results/PackageSummaryResponse.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/results/PackageSummaryResponse.java
@@ -1,0 +1,31 @@
+package com.github.gradusnikov.eclipse.assistai.mcp.results;
+
+import java.util.List;
+
+public record PackageSummaryResponse(
+    String packageName,
+    String projectName,
+    int totalTypes,
+    List<TypeSummary> types,
+    String summaryText
+)
+{
+    public record TypeSummary(
+        String simpleName,
+        String typeKind,
+        String javadocSummary,
+        int methodCount,
+        int fieldCount,
+        List<String> superInterfaces
+    )
+    {
+    }
+
+    public static PackageSummaryResponse of( String packageName, String projectName, List<TypeSummary> types )
+    {
+        String summary = types.isEmpty()
+                ? "Package '" + packageName + "' is empty or not found."
+                : types.size() + ( types.size() == 1 ? " type" : " types" ) + " in package '" + packageName + "'.";
+        return new PackageSummaryResponse( packageName, projectName, types.size(), types, summary );
+    }
+}

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/results/TypeSearchResponse.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/results/TypeSearchResponse.java
@@ -1,0 +1,39 @@
+package com.github.gradusnikov.eclipse.assistai.mcp.results;
+
+import java.util.List;
+
+public record TypeSearchResponse(
+    String pattern,
+    int totalMatches,
+    List<TypeMatch> types,
+    boolean truncated,
+    String summaryText
+)
+{
+    public record TypeMatch(
+        String fullyQualifiedName,
+        String simpleName,
+        String packageName,
+        String projectName,
+        String typeKind
+    )
+    {
+    }
+
+    public static TypeSearchResponse of( String pattern, List<TypeMatch> types, int limit )
+    {
+        boolean truncated = limit > 0 && types.size() > limit;
+        List<TypeMatch> shown = truncated ? types.subList( 0, limit ) : types;
+        return new TypeSearchResponse( pattern, types.size(), shown, truncated, summarize( types.size(), truncated, shown.size() ) );
+    }
+
+    private static String summarize( int total, boolean truncated, int shown )
+    {
+        if ( total == 0 )
+        {
+            return "No types found.";
+        }
+        String summary = total + ( total == 1 ? " type found." : " types found." );
+        return truncated ? summary + " Showing the first " + shown + "." : summary;
+    }
+}

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/results/WorkspaceOverviewResponse.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/results/WorkspaceOverviewResponse.java
@@ -1,0 +1,39 @@
+package com.github.gradusnikov.eclipse.assistai.mcp.results;
+
+import java.util.List;
+
+public record WorkspaceOverviewResponse(
+    int totalProjects,
+    int totalPackages,
+    int totalTypes,
+    List<ProjectOverview> projects,
+    String summaryText
+)
+{
+    public record ProjectOverview(
+        String projectName,
+        int packageCount,
+        int typeCount,
+        List<PackageOverview> packages
+    )
+    {
+    }
+
+    public record PackageOverview(
+        String packageName,
+        int typeCount,
+        List<String> typeNames
+    )
+    {
+    }
+
+    public static WorkspaceOverviewResponse of( List<ProjectOverview> projects )
+    {
+        int totalPackages = projects.stream().mapToInt( ProjectOverview::packageCount ).sum();
+        int totalTypes = projects.stream().mapToInt( ProjectOverview::typeCount ).sum();
+        String summary = projects.size() + ( projects.size() == 1 ? " project, " : " projects, " )
+                + totalPackages + ( totalPackages == 1 ? " package, " : " packages, " )
+                + totalTypes + ( totalTypes == 1 ? " type." : " types." );
+        return new WorkspaceOverviewResponse( projects.size(), totalPackages, totalTypes, projects, summary );
+    }
+}

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/EclipseIntegrationsMcpServer.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/EclipseIntegrationsMcpServer.java
@@ -17,8 +17,10 @@ import com.github.gradusnikov.eclipse.assistai.mcp.results.JavaDocResponse;
 import com.github.gradusnikov.eclipse.assistai.mcp.results.MarkdownOutlineResponse;
 import com.github.gradusnikov.eclipse.assistai.mcp.results.MavenDependenciesResponse;
 import com.github.gradusnikov.eclipse.assistai.mcp.results.MavenProjectListResponse;
+import com.github.gradusnikov.eclipse.assistai.mcp.results.MethodSearchResponse;
 import com.github.gradusnikov.eclipse.assistai.mcp.results.MethodSourceResponse;
 import com.github.gradusnikov.eclipse.assistai.mcp.results.OpenProjectResponse;
+import com.github.gradusnikov.eclipse.assistai.mcp.results.PackageSummaryResponse;
 import com.github.gradusnikov.eclipse.assistai.mcp.results.ProjectLayoutResponse;
 import com.github.gradusnikov.eclipse.assistai.mcp.results.ProjectListResponse;
 import com.github.gradusnikov.eclipse.assistai.mcp.results.ProjectPropertiesResponse;
@@ -30,9 +32,12 @@ import com.github.gradusnikov.eclipse.assistai.mcp.results.TestClassesResponse;
 import com.github.gradusnikov.eclipse.assistai.mcp.results.TestRunResponse;
 import com.github.gradusnikov.eclipse.assistai.mcp.results.TypeHierarchyResponse;
 import com.github.gradusnikov.eclipse.assistai.mcp.results.TypeResolutionResponse;
+import com.github.gradusnikov.eclipse.assistai.mcp.results.TypeSearchResponse;
+import com.github.gradusnikov.eclipse.assistai.mcp.results.WorkspaceOverviewResponse;
 import com.github.gradusnikov.eclipse.assistai.mcp.annotations.Tool;
 import com.github.gradusnikov.eclipse.assistai.mcp.annotations.ToolParam;
 import com.github.gradusnikov.eclipse.assistai.mcp.services.CodeAnalysisService;
+import com.github.gradusnikov.eclipse.assistai.mcp.services.CodeDiscoveryService;
 import com.github.gradusnikov.eclipse.assistai.mcp.services.CodeEditingService;
 import com.github.gradusnikov.eclipse.assistai.mcp.services.ConsoleService;
 import com.github.gradusnikov.eclipse.assistai.mcp.services.EditorService;
@@ -88,6 +93,10 @@ public class EclipseIntegrationsMcpServer
 
     @Inject
     private MarkdownService     markdownService;
+
+    @Inject
+    private CodeDiscoveryService codeDiscoveryService;
+
 
     @Tool( name = "formatCode", description = "Formats code according to the current Eclipse formatter settings.", type = "object" )
     public String formatCode( @ToolParam( name = "code", description = "The code to be formatted", required = true )
@@ -636,4 +645,118 @@ public class EclipseIntegrationsMcpServer
         }
         return fileNamePatterns.trim().split( "\\s*,\\s*" );
     }
+
+    private static Integer parseOptionalInt( String value )
+    {
+        if ( value == null || value.isBlank() )
+        {
+            return null;
+        }
+        try
+        {
+            return Integer.parseInt( value.trim() );
+        }
+        catch ( NumberFormatException e )
+        {
+            return null;
+        }
+    }
+
+
+    @Tool( name = "searchTypes",
+           longExecution = true,
+           description = "Searches for Java types (classes, interfaces, enums, records, annotations) by name pattern. "
+                       + "This is the primary discovery tool — use it FIRST when a user mentions a concept (e.g. 'payment handling', "
+                       + "'authentication') and you need to find which classes implement it. "
+                       + "Supports wildcards (* and ?), CamelCase matching (e.g. 'PS' finds 'PaymentService'), and prefix matching. "
+                       + "Prefer this over fileSearch for finding types: it searches the JDT index (instant) rather than file contents, "
+                       + "and supports CamelCase patterns that text search cannot. "
+                       + "After finding types, use getClassOutline or getPackageSummary to understand them, "
+                       + "then getMethodSource to read specific methods.",
+           type = "object",
+           outputType = TypeSearchResponse.class )
+    public TypeSearchResponse searchTypes(
+            @ToolParam( name = "pattern", description = "Type name pattern. Supports: "
+                                                      + "wildcards (*Payment*, *Service, Error*), "
+                                                      + "CamelCase (PS -> PaymentService, TxH -> TransactionHandler, CC -> CreditCard), "
+                                                      + "prefix (Payment -> PaymentService, PaymentProcessor, ...), "
+                                                      + "or package-qualified (com.example.*Service). "
+                                                      + "Tips: try multiple patterns for a concept — e.g. for 'payment' try '*Payment*', '*Billing*', '*Transaction*'.", required = true )
+            String pattern,
+            @ToolParam( name = "maxResults", description = "Maximum number of results to return (default: 100)", required = false )
+            String maxResults )
+    {
+        Integer limit = parseOptionalInt( maxResults );
+        return codeDiscoveryService.searchTypes( pattern, limit );
+    }
+
+    @Tool( name = "searchMethods",
+           longExecution = true,
+           description = "Searches for methods by name pattern across the entire workspace. "
+                       + "Use this when you know (or can guess) a method name but don't know which class contains it. "
+                       + "For example, if a user says 'fix the error handling', search for '*error*' or 'handle*' to find relevant methods. "
+                       + "Supports wildcards (* and ?), CamelCase matching, and prefix matching. "
+                       + "Optionally filter by declaring type to narrow results. "
+                       + "Returns the method name, declaring class, package, parameter types, and return type. "
+                       + "After finding a method, use getMethodSource to read its implementation.",
+           type = "object",
+           outputType = MethodSearchResponse.class )
+    public MethodSearchResponse searchMethods(
+            @ToolParam( name = "pattern", description = "Method name pattern. Supports: "
+                                                      + "wildcards (handle*Error, get*, *Payment, process*), "
+                                                      + "CamelCase (pP -> processPayment — requires 2+ uppercase letters), "
+                                                      + "or prefix (handle -> handleError, handleTimeout, ...). "
+                                                      + "Note: CamelCase and prefix patterns are case-sensitive; use wildcards (*foo*) for case-insensitive matching.", required = true )
+            String pattern,
+            @ToolParam( name = "declaringTypePattern", description = "Optional pattern to filter by declaring type name (e.g. '*Service', 'Payment*'). "
+                                                                   + "Useful when the method name is common (e.g. 'get*') and you want to narrow to specific classes.", required = false )
+            String declaringTypePattern,
+            @ToolParam( name = "maxResults", description = "Maximum number of results to return (default: 100)", required = false )
+            String maxResults )
+    {
+        Integer limit = parseOptionalInt( maxResults );
+        return codeDiscoveryService.searchMethods( pattern, declaringTypePattern, limit );
+    }
+
+    @Tool( name = "getPackageSummary",
+           longExecution = true,
+           description = "Returns a table-of-contents for a Java package: every type's name, kind (class/interface/enum/record), "
+                       + "Javadoc first sentence, method count, field count, and implemented interfaces — all in one call. "
+                       + "Use this after searchTypes or getWorkspaceOverview identifies a relevant package, "
+                       + "to understand what the package contains without reading each file individually. "
+                       + "The Javadoc summaries help you decide which types are relevant to the user's request. "
+                       + "Follow up with getClassOutline or getMethodSource on specific types of interest.",
+           type = "object",
+           outputType = PackageSummaryResponse.class )
+    public PackageSummaryResponse getPackageSummary(
+            @ToolParam( name = "packageName", description = "Fully qualified package name (e.g. 'com.example.payment', 'org.acme.auth.service')", required = true )
+            String packageName,
+            @ToolParam( name = "projectName", description = "Optional project name to narrow the search. Useful in multi-project workspaces.", required = false )
+            String projectName )
+    {
+        return codeDiscoveryService.getPackageSummary( packageName, projectName );
+    }
+
+    @Tool( name = "getWorkspaceOverview",
+           longExecution = true,
+           description = "Returns a high-level architectural map of the workspace: all projects, their source packages, "
+                       + "and the type names in each package. Use this as the FIRST tool when orienting in an unfamiliar codebase "
+                       + "or when you need to understand the overall project structure before making changes. "
+                       + "Typical workflow: getWorkspaceOverview -> identify relevant packages -> getPackageSummary on those packages "
+                       + "-> getClassOutline/getMethodSource on specific types. "
+                       + "For large workspaces, use projectFilter to focus on specific projects.",
+           type = "object",
+           outputType = WorkspaceOverviewResponse.class )
+    public WorkspaceOverviewResponse getWorkspaceOverview(
+            @ToolParam( name = "projectFilter", description = "Optional substring to filter projects by name (e.g. 'payment' shows only payment-related projects, "
+                                                            + "'service' shows service projects). Leave empty to see all projects.", required = false )
+            String projectFilter,
+            @ToolParam( name = "maxPackagesPerProject", description = "Maximum number of packages to show per project (default: 50). "
+                                                                    + "Lower this for large projects to get a quick overview.", required = false )
+            String maxPackagesPerProject )
+    {
+        Integer maxPkgs = parseOptionalInt( maxPackagesPerProject );
+        return codeDiscoveryService.getWorkspaceOverview( projectFilter, maxPkgs );
+    }
+
 }

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeDiscoveryService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeDiscoveryService.java
@@ -1,0 +1,495 @@
+package com.github.gradusnikov.eclipse.assistai.mcp.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.e4.core.di.annotations.Creatable;
+import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.SearchMatch;
+import org.eclipse.jdt.core.search.SearchParticipant;
+import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.core.search.SearchRequestor;
+import org.eclipse.jdt.core.search.TypeNameMatch;
+import org.eclipse.jdt.core.search.TypeNameMatchRequestor;
+
+import com.github.gradusnikov.eclipse.assistai.mcp.results.MethodSearchResponse;
+import com.github.gradusnikov.eclipse.assistai.mcp.results.PackageSummaryResponse;
+import com.github.gradusnikov.eclipse.assistai.mcp.results.TypeSearchResponse;
+import com.github.gradusnikov.eclipse.assistai.mcp.results.WorkspaceOverviewResponse;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+@Creatable
+@Singleton
+public class CodeDiscoveryService
+{
+    private static final int DEFAULT_LIMIT = 100;
+
+    @Inject
+    private ILog logger;
+
+    public TypeSearchResponse searchTypes( String pattern, Integer maxResults )
+    {
+        int limit = maxResults != null && maxResults > 0 ? maxResults : DEFAULT_LIMIT;
+        int collectLimit = limit * 2;
+
+        try
+        {
+            var scope = SearchEngine.createWorkspaceScope();
+            var engine = new SearchEngine();
+            var matches = new ArrayList<TypeSearchResponse.TypeMatch>();
+
+            int matchRule = determineMatchRule( pattern );
+            char[] packagePattern = null;
+            char[] typePattern = pattern.toCharArray();
+
+            if ( pattern.contains( "." ) )
+            {
+                int lastDot = pattern.lastIndexOf( '.' );
+                packagePattern = pattern.substring( 0, lastDot ).toCharArray();
+                typePattern = pattern.substring( lastDot + 1 ).toCharArray();
+            }
+
+            engine.searchAllTypeNames(
+                    packagePattern,
+                    packagePattern != null ? SearchPattern.R_PATTERN_MATCH : 0,
+                    typePattern,
+                    matchRule,
+                    IJavaSearchConstants.TYPE,
+                    scope,
+                    new TypeNameMatchRequestor()
+                    {
+                        @Override
+                        public void acceptTypeNameMatch( TypeNameMatch match )
+                        {
+                            if ( matches.size() >= collectLimit )
+                            {
+                                return;
+                            }
+                            IType type = match.getType();
+                            if ( type == null )
+                            {
+                                return;
+                            }
+                            IJavaProject project = type.getJavaProject();
+                            String projectName = project != null ? project.getElementName() : null;
+
+                            matches.add( new TypeSearchResponse.TypeMatch(
+                                    match.getFullyQualifiedName(),
+                                    match.getSimpleTypeName(),
+                                    match.getPackageName(),
+                                    projectName,
+                                    typeKindLabel( type ) ) );
+                        }
+                    },
+                    IJavaSearchConstants.WAIT_UNTIL_READY_TO_SEARCH,
+                    new NullProgressMonitor() );
+
+            return TypeSearchResponse.of( pattern, matches, limit );
+        }
+        catch ( JavaModelException e )
+        {
+            logger.error( e.getMessage(), e );
+            throw new RuntimeException( "Error searching types: " + e.getMessage(), e );
+        }
+    }
+
+    public MethodSearchResponse searchMethods( String pattern, String declaringTypePattern, Integer maxResults )
+    {
+        int limit = maxResults != null && maxResults > 0 ? maxResults : DEFAULT_LIMIT;
+        int collectLimit = limit * 2;
+
+        try
+        {
+            var scope = SearchEngine.createWorkspaceScope();
+            var engine = new SearchEngine();
+            var matches = new ArrayList<MethodSearchResponse.MethodMatch>();
+
+            int matchRule = determineMatchRule( pattern );
+            char[] methodPattern = pattern.toCharArray();
+            char[] qualifyingType = declaringTypePattern != null && !declaringTypePattern.isBlank()
+                    ? declaringTypePattern.toCharArray()
+                    : null;
+
+            engine.searchAllMethodNames(
+                    qualifyingType,
+                    qualifyingType != null ? determineMatchRule( declaringTypePattern ) : 0,
+                    methodPattern,
+                    matchRule,
+                    scope,
+                    new org.eclipse.jdt.core.search.MethodNameMatchRequestor()
+                    {
+                        @Override
+                        public void acceptMethodNameMatch( org.eclipse.jdt.core.search.MethodNameMatch match )
+                        {
+                            if ( matches.size() >= collectLimit )
+                            {
+                                return;
+                            }
+                            IMethod method = match.getMethod();
+                            if ( method == null )
+                            {
+                                return;
+                            }
+                            IType declaringType = method.getDeclaringType();
+                            IJavaProject project = method.getJavaProject();
+
+                            List<String> paramTypes = new ArrayList<>();
+                            for ( String paramSig : method.getParameterTypes() )
+                            {
+                                paramTypes.add( Signature.toString( paramSig ) );
+                            }
+
+                            String returnType = null;
+                            try
+                            {
+                                returnType = Signature.toString( method.getReturnType() );
+                            }
+                            catch ( JavaModelException e )
+                            {
+                                // ignore
+                            }
+
+                            matches.add( new MethodSearchResponse.MethodMatch(
+                                    method.getElementName(),
+                                    declaringType != null ? declaringType.getFullyQualifiedName() : null,
+                                    declaringType != null ? declaringType.getPackageFragment().getElementName() : null,
+                                    project != null ? project.getElementName() : null,
+                                    returnType,
+                                    paramTypes ) );
+                        }
+                    },
+                    IJavaSearchConstants.WAIT_UNTIL_READY_TO_SEARCH,
+                    new NullProgressMonitor() );
+
+            return MethodSearchResponse.of( pattern, matches, limit );
+        }
+        catch ( JavaModelException e )
+        {
+            logger.error( e.getMessage(), e );
+            throw new RuntimeException( "Error searching methods: " + e.getMessage(), e );
+        }
+    }
+
+    public PackageSummaryResponse getPackageSummary( String packageName, String projectName )
+    {
+        try
+        {
+            IPackageFragment pkg = findPackage( packageName, projectName );
+            if ( pkg == null )
+            {
+                return PackageSummaryResponse.of( packageName, projectName, List.of() );
+            }
+
+            String resolvedProject = pkg.getJavaProject().getElementName();
+            var types = new ArrayList<PackageSummaryResponse.TypeSummary>();
+
+            for ( var cu : pkg.getCompilationUnits() )
+            {
+                for ( IType type : cu.getTypes() )
+                {
+                    String javadocSummary = extractFirstSentence( type );
+                    String typeKind = typeKindLabel( type );
+
+                    int methodCount = type.getMethods().length;
+                    int fieldCount = type.getFields().length;
+
+                    List<String> superInterfaces = new ArrayList<>();
+                    for ( String iface : type.getSuperInterfaceNames() )
+                    {
+                        superInterfaces.add( iface );
+                    }
+
+                    types.add( new PackageSummaryResponse.TypeSummary(
+                            type.getElementName(),
+                            typeKind,
+                            javadocSummary,
+                            methodCount,
+                            fieldCount,
+                            superInterfaces ) );
+                }
+            }
+
+            return PackageSummaryResponse.of( packageName, resolvedProject, types );
+        }
+        catch ( JavaModelException e )
+        {
+            logger.error( e.getMessage(), e );
+            throw new RuntimeException( "Error getting package summary: " + e.getMessage(), e );
+        }
+    }
+
+    public WorkspaceOverviewResponse getWorkspaceOverview( String projectFilter, Integer maxPackagesPerProject )
+    {
+        int maxPkgs = maxPackagesPerProject != null && maxPackagesPerProject > 0 ? maxPackagesPerProject : 50;
+
+        try
+        {
+            var projects = new ArrayList<WorkspaceOverviewResponse.ProjectOverview>();
+
+            for ( IJavaProject javaProject : getAvailableJavaProjects() )
+            {
+                String name = javaProject.getElementName();
+                if ( projectFilter != null && !projectFilter.isBlank() && !name.contains( projectFilter ) )
+                {
+                    continue;
+                }
+
+                var packageOverviews = new ArrayList<WorkspaceOverviewResponse.PackageOverview>();
+                int totalTypes = 0;
+                int totalPackageCount = 0;
+
+                for ( IPackageFragmentRoot root : javaProject.getPackageFragmentRoots() )
+                {
+                    if ( root.getKind() != IPackageFragmentRoot.K_SOURCE )
+                    {
+                        continue;
+                    }
+
+                    for ( IJavaElement child : root.getChildren() )
+                    {
+                        if ( !( child instanceof IPackageFragment pkg ) || pkg.getCompilationUnits().length == 0 )
+                        {
+                            continue;
+                        }
+
+                        totalPackageCount++;
+
+                        var typeNames = new ArrayList<String>();
+                        for ( var cu : pkg.getCompilationUnits() )
+                        {
+                            for ( IType type : cu.getTypes() )
+                            {
+                                typeNames.add( type.getElementName() );
+                            }
+                        }
+
+                        totalTypes += typeNames.size();
+
+                        if ( packageOverviews.size() < maxPkgs )
+                        {
+                            packageOverviews.add( new WorkspaceOverviewResponse.PackageOverview(
+                                    pkg.getElementName(),
+                                    typeNames.size(),
+                                    typeNames ) );
+                        }
+                    }
+                }
+
+                projects.add( new WorkspaceOverviewResponse.ProjectOverview(
+                        name,
+                        totalPackageCount,
+                        totalTypes,
+                        packageOverviews ) );
+            }
+
+            return WorkspaceOverviewResponse.of( projects );
+        }
+        catch ( JavaModelException e )
+        {
+            logger.error( e.getMessage(), e );
+            throw new RuntimeException( "Error building workspace overview: " + e.getMessage(), e );
+        }
+    }
+
+    private int determineMatchRule( String pattern )
+    {
+        if ( pattern.contains( "*" ) || pattern.contains( "?" ) )
+        {
+            return SearchPattern.R_PATTERN_MATCH;
+        }
+        if ( isCamelCasePattern( pattern ) )
+        {
+            return SearchPattern.R_CAMELCASE_MATCH;
+        }
+        return SearchPattern.R_PREFIX_MATCH | SearchPattern.R_CASE_SENSITIVE;
+    }
+
+    private boolean isCamelCasePattern( String pattern )
+    {
+        if ( pattern.isEmpty() )
+        {
+            return false;
+        }
+        if ( !Character.isLetter( pattern.charAt( 0 ) ) )
+        {
+            return false;
+        }
+        int upperCount = 0;
+        for ( char c : pattern.toCharArray() )
+        {
+            if ( Character.isUpperCase( c ) )
+            {
+                upperCount++;
+            }
+        }
+        return upperCount >= 2;
+    }
+
+    private String typeKindLabel( IType type )
+    {
+        try
+        {
+            if ( type.isInterface() )
+            {
+                return "interface";
+            }
+            if ( type.isEnum() )
+            {
+                return "enum";
+            }
+            if ( type.isRecord() )
+            {
+                return "record";
+            }
+            if ( type.isAnnotation() )
+            {
+                return "annotation";
+            }
+            if ( Flags.isAbstract( type.getFlags() ) )
+            {
+                return "abstract class";
+            }
+        }
+        catch ( JavaModelException e )
+        {
+            // fall through
+        }
+        return "class";
+    }
+
+    private String extractFirstSentence( IType type )
+    {
+        try
+        {
+            var javadocRange = type.getJavadocRange();
+            if ( javadocRange == null )
+            {
+                return null;
+            }
+
+            var cu = type.getCompilationUnit();
+            if ( cu == null )
+            {
+                return null;
+            }
+
+            String cuSource = cu.getSource();
+            if ( cuSource == null )
+            {
+                return null;
+            }
+
+            int offset = javadocRange.getOffset();
+            int length = javadocRange.getLength();
+            if ( offset + length > cuSource.length() )
+            {
+                return null;
+            }
+
+            String javadoc = cuSource.substring( offset, offset + length );
+            if ( javadoc.startsWith( "/**" ) )
+            {
+                javadoc = javadoc.substring( 3 );
+            }
+            if ( javadoc.endsWith( "*/" ) )
+            {
+                javadoc = javadoc.substring( 0, javadoc.length() - 2 );
+            }
+            javadoc = javadoc.replaceAll( "(?m)^\\s*\\*\\s?", "" ).trim();
+
+            if ( javadoc.startsWith( "@" ) )
+            {
+                return null;
+            }
+
+            int atIdx = javadoc.indexOf( "\n@" );
+            if ( atIdx > 0 )
+            {
+                javadoc = javadoc.substring( 0, atIdx ).trim();
+            }
+
+            int dotIdx = javadoc.indexOf( '.' );
+            if ( dotIdx > 0 && dotIdx < 200 )
+            {
+                return javadoc.substring( 0, dotIdx + 1 ).trim();
+            }
+
+            if ( javadoc.length() > 200 )
+            {
+                return javadoc.substring( 0, 200 ).trim() + "...";
+            }
+
+            return javadoc.isEmpty() ? null : javadoc;
+        }
+        catch ( JavaModelException e )
+        {
+            return null;
+        }
+    }
+
+    private IPackageFragment findPackage( String packageName, String projectName ) throws JavaModelException
+    {
+        for ( IJavaProject project : getAvailableJavaProjects() )
+        {
+            if ( projectName != null && !projectName.isBlank() && !project.getElementName().equals( projectName ) )
+            {
+                continue;
+            }
+
+            for ( IPackageFragmentRoot root : project.getPackageFragmentRoots() )
+            {
+                if ( root.getKind() != IPackageFragmentRoot.K_SOURCE )
+                {
+                    continue;
+                }
+
+                IPackageFragment pkg = root.getPackageFragment( packageName );
+                if ( pkg != null && pkg.exists() )
+                {
+                    return pkg;
+                }
+            }
+        }
+        return null;
+    }
+
+    private List<IJavaProject> getAvailableJavaProjects()
+    {
+        List<IJavaProject> javaProjects = new ArrayList<>();
+        try
+        {
+            IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
+            for ( IProject project : projects )
+            {
+                if ( project.isOpen() && project.hasNature( JavaCore.NATURE_ID ) )
+                {
+                    javaProjects.add( JavaCore.create( project ) );
+                }
+            }
+        }
+        catch ( CoreException e )
+        {
+            throw new RuntimeException( e );
+        }
+        return javaProjects;
+    }
+}

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeDiscoveryServicePDETest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeDiscoveryServicePDETest.java
@@ -1,0 +1,662 @@
+package com.github.gradusnikov.eclipse.assistai.mcp.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.EclipseContextFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.launching.JavaRuntime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.util.tracker.ServiceTracker;
+
+import com.github.gradusnikov.eclipse.assistai.Activator;
+import com.github.gradusnikov.eclipse.assistai.mcp.results.MethodSearchResponse;
+import com.github.gradusnikov.eclipse.assistai.mcp.results.PackageSummaryResponse;
+import com.github.gradusnikov.eclipse.assistai.mcp.results.TypeSearchResponse;
+import com.github.gradusnikov.eclipse.assistai.mcp.results.WorkspaceOverviewResponse;
+
+public class CodeDiscoveryServicePDETest
+{
+    private static final String TEST_PROJECT_NAME_PREFIX = "CodeDiscoveryTestProject";
+    private String testProjectName;
+    private IProject project;
+    private IJavaProject javaProject;
+    private CodeDiscoveryService service;
+    private NullProgressMonitor monitor = new NullProgressMonitor();
+
+    @BeforeEach
+    public void beforeEach() throws CoreException, IOException, InterruptedException
+    {
+        BundleContext bundleContext = FrameworkUtil.getBundle( CodeDiscoveryServicePDETest.class ).getBundleContext();
+        ServiceTracker<IWorkspace, IWorkspace> workspaceTracker = new ServiceTracker<>( bundleContext, IWorkspace.class, null );
+
+        workspaceTracker.open();
+        IWorkspace workspace = workspaceTracker.getService();
+        IWorkspaceRoot root = workspace.getRoot();
+        testProjectName = TEST_PROJECT_NAME_PREFIX + "_" + UUID.randomUUID();
+
+        project = root.getProject( testProjectName );
+        if ( project.exists() )
+        {
+            project.delete( true, true, monitor );
+        }
+
+        project = root.getProject( testProjectName );
+        IProjectDescription desc = project.getWorkspace().newProjectDescription( project.getName() );
+        project.create( desc, monitor );
+        project.open( monitor );
+
+        IProjectDescription openDesc = project.getDescription();
+        openDesc.setNatureIds( new String[] { JavaCore.NATURE_ID } );
+        project.setDescription( openDesc, monitor );
+
+        javaProject = JavaCore.create( project );
+
+        javaProject.setOption( JavaCore.COMPILER_COMPLIANCE, "21" );
+        javaProject.setOption( JavaCore.COMPILER_SOURCE, "21" );
+        javaProject.setOption( JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, "21" );
+
+        IFolder binFolder = project.getFolder( "bin" );
+        if ( !binFolder.exists() )
+        {
+            binFolder.create( true, true, monitor );
+        }
+        javaProject.setOutputLocation( binFolder.getFullPath(), monitor );
+
+        IFolder srcFolder = project.getFolder( "src" );
+        if ( !srcFolder.exists() )
+        {
+            srcFolder.create( IResource.NONE, true, monitor );
+        }
+
+        javaProject.setRawClasspath(
+                new org.eclipse.jdt.core.IClasspathEntry[] {
+                        JavaCore.newSourceEntry( project.getFullPath().append( "src" ) ),
+                        JavaRuntime.getDefaultJREContainerEntry()
+                },
+                monitor );
+
+        createPackageStructure();
+        createTestClasses();
+
+        project.build( IncrementalProjectBuilder.FULL_BUILD, monitor );
+        Job.getJobManager().join( ResourcesPlugin.FAMILY_MANUAL_BUILD, monitor );
+        Job.getJobManager().join( ResourcesPlugin.FAMILY_AUTO_BUILD, monitor );
+        Thread.sleep( 500 );
+
+        IEclipseContext context = EclipseContextFactory.create();
+        context.set( ILog.class, Activator.getDefault().getLog() );
+        service = ContextInjectionFactory.make( CodeDiscoveryService.class, context );
+    }
+
+    @AfterEach
+    public void afterEach() throws CoreException, InterruptedException
+    {
+        Job.getJobManager().join( ResourcesPlugin.FAMILY_MANUAL_BUILD, monitor );
+        Job.getJobManager().join( ResourcesPlugin.FAMILY_AUTO_BUILD, monitor );
+        Thread.sleep( 500 );
+
+        org.eclipse.ui.PlatformUI.getWorkbench().getDisplay().syncExec( () -> {
+            org.eclipse.ui.IWorkbenchWindow window =
+                    org.eclipse.ui.PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+            if ( window != null )
+            {
+                org.eclipse.ui.IWorkbenchPage page = window.getActivePage();
+                if ( page != null )
+                {
+                    page.closeAllEditors( false );
+                }
+            }
+        } );
+
+        if ( project != null && project.exists() )
+        {
+            if ( project.isOpen() )
+            {
+                project.close( monitor );
+            }
+            for ( int attempt = 0; attempt < 10; attempt++ )
+            {
+                try
+                {
+                    project.delete( true, true, monitor );
+                    break;
+                }
+                catch ( CoreException e )
+                {
+                    if ( attempt == 9 )
+                    {
+                        project.delete( false, true, monitor );
+                        break;
+                    }
+                    Thread.sleep( 1000 );
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // searchTypes
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testSearchTypes_WildcardPattern()
+    {
+        TypeSearchResponse result = service.searchTypes( "*PaymentService*", null );
+
+        assertNotNull( result );
+        assertEquals( "*PaymentService*", result.pattern() );
+        assertTrue( result.totalMatches() >= 1, "Should find PaymentService" );
+        assertTrue( result.types().stream()
+                .anyMatch( t -> "PaymentService".equals( t.simpleName() ) ) );
+    }
+
+    @Test
+    public void testSearchTypes_CamelCasePattern()
+    {
+        TypeSearchResponse result = service.searchTypes( "PS", null );
+
+        assertNotNull( result );
+        assertTrue( result.types().stream()
+                .anyMatch( t -> "PaymentService".equals( t.simpleName() ) ),
+                "CamelCase 'PS' should match PaymentService" );
+    }
+
+    @Test
+    public void testSearchTypes_PrefixPattern()
+    {
+        TypeSearchResponse result = service.searchTypes( "Payment", null );
+
+        assertNotNull( result );
+        assertTrue( result.totalMatches() >= 1 );
+        assertTrue( result.types().stream()
+                .anyMatch( t -> t.simpleName().startsWith( "Payment" ) ) );
+    }
+
+    @Test
+    public void testSearchTypes_QualifiedPattern()
+    {
+        TypeSearchResponse result = service.searchTypes( "com.example.payment.*Service", null );
+
+        assertNotNull( result );
+        assertTrue( result.totalMatches() >= 1 );
+        assertTrue( result.types().stream()
+                .anyMatch( t -> "com.example.payment".equals( t.packageName() ) ) );
+    }
+
+    @Test
+    public void testSearchTypes_NoMatch()
+    {
+        TypeSearchResponse result = service.searchTypes( "XyzNonExistentClass999", null );
+
+        assertNotNull( result );
+        assertEquals( 0, result.totalMatches() );
+        assertTrue( result.types().isEmpty() );
+    }
+
+    @Test
+    public void testSearchTypes_MaxResults()
+    {
+        TypeSearchResponse result = service.searchTypes( "*", 2 );
+
+        assertNotNull( result );
+        assertTrue( result.types().size() <= 2 );
+        if ( result.totalMatches() > 2 )
+        {
+            assertTrue( result.truncated() );
+        }
+    }
+
+    @Test
+    public void testSearchTypes_ReturnsTypeKind()
+    {
+        TypeSearchResponse result = service.searchTypes( "*PaymentProcessor*", null );
+
+        assertNotNull( result );
+        assertTrue( result.types().stream()
+                .anyMatch( t -> "interface".equals( t.typeKind() ) ),
+                "PaymentProcessor is an interface" );
+    }
+
+    // -------------------------------------------------------------------------
+    // searchMethods
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testSearchMethods_WildcardPattern()
+    {
+        MethodSearchResponse result = service.searchMethods( "process*", null, null );
+
+        assertNotNull( result );
+        assertTrue( result.totalMatches() >= 1 );
+        assertTrue( result.methods().stream()
+                .anyMatch( m -> m.methodName().startsWith( "process" ) ) );
+    }
+
+    @Test
+    public void testSearchMethods_ExactName()
+    {
+        MethodSearchResponse result = service.searchMethods( "handleError", null, null );
+
+        assertNotNull( result );
+        assertTrue( result.totalMatches() >= 1 );
+        assertTrue( result.methods().stream()
+                .anyMatch( m -> "handleError".equals( m.methodName() ) ) );
+    }
+
+    @Test
+    public void testSearchMethods_WithDeclaringTypeFilter()
+    {
+        MethodSearchResponse result = service.searchMethods( "process*", "*PaymentService*", null );
+
+        assertNotNull( result );
+        assertTrue( result.totalMatches() >= 1 );
+        assertTrue( result.methods().stream()
+                .allMatch( m -> m.declaringType() != null && m.declaringType().contains( "PaymentService" ) ) );
+    }
+
+    @Test
+    public void testSearchMethods_NoMatch()
+    {
+        MethodSearchResponse result = service.searchMethods( "xyzNonExistentMethod999", null, null );
+
+        assertNotNull( result );
+        assertEquals( 0, result.totalMatches() );
+        assertTrue( result.methods().isEmpty() );
+    }
+
+    @Test
+    public void testSearchMethods_ReturnsParameterTypes()
+    {
+        MethodSearchResponse result = service.searchMethods( "processPayment", null, null );
+
+        assertNotNull( result );
+        assertTrue( result.totalMatches() >= 1 );
+        var method = result.methods().stream()
+                .filter( m -> "processPayment".equals( m.methodName() ) )
+                .findFirst()
+                .orElseThrow();
+        assertFalse( method.parameterTypes().isEmpty(), "processPayment takes parameters" );
+    }
+
+    // -------------------------------------------------------------------------
+    // getPackageSummary
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testGetPackageSummary_ExistingPackage()
+    {
+        PackageSummaryResponse result = service.getPackageSummary( "com.example.payment", testProjectName );
+
+        assertNotNull( result );
+        assertEquals( "com.example.payment", result.packageName() );
+        assertTrue( result.totalTypes() >= 2, "Should find PaymentService and PaymentProcessor" );
+        assertTrue( result.types().stream()
+                .anyMatch( t -> "PaymentService".equals( t.simpleName() ) ) );
+        assertTrue( result.types().stream()
+                .anyMatch( t -> "PaymentProcessor".equals( t.simpleName() ) ) );
+    }
+
+    @Test
+    public void testGetPackageSummary_ReportsTypeKind()
+    {
+        PackageSummaryResponse result = service.getPackageSummary( "com.example.payment", testProjectName );
+
+        var processor = result.types().stream()
+                .filter( t -> "PaymentProcessor".equals( t.simpleName() ) )
+                .findFirst()
+                .orElseThrow();
+        assertEquals( "interface", processor.typeKind() );
+
+        var serviceType = result.types().stream()
+                .filter( t -> "PaymentService".equals( t.simpleName() ) )
+                .findFirst()
+                .orElseThrow();
+        assertEquals( "class", serviceType.typeKind() );
+    }
+
+    @Test
+    public void testGetPackageSummary_ReportsJavadoc()
+    {
+        PackageSummaryResponse result = service.getPackageSummary( "com.example.payment", testProjectName );
+
+        var serviceType = result.types().stream()
+                .filter( t -> "PaymentService".equals( t.simpleName() ) )
+                .findFirst()
+                .orElseThrow();
+        assertNotNull( serviceType.javadocSummary() );
+        assertTrue( serviceType.javadocSummary().contains( "payment" ),
+                "Javadoc should mention payment: " + serviceType.javadocSummary() );
+    }
+
+    @Test
+    public void testGetPackageSummary_ReportsMethodAndFieldCounts()
+    {
+        PackageSummaryResponse result = service.getPackageSummary( "com.example.payment", testProjectName );
+
+        var serviceType = result.types().stream()
+                .filter( t -> "PaymentService".equals( t.simpleName() ) )
+                .findFirst()
+                .orElseThrow();
+        assertTrue( serviceType.methodCount() >= 2, "PaymentService has processPayment and handleError" );
+    }
+
+    @Test
+    public void testGetPackageSummary_ReportsSuperInterfaces()
+    {
+        PackageSummaryResponse result = service.getPackageSummary( "com.example.payment", testProjectName );
+
+        var serviceType = result.types().stream()
+                .filter( t -> "PaymentService".equals( t.simpleName() ) )
+                .findFirst()
+                .orElseThrow();
+        assertTrue( serviceType.superInterfaces().contains( "PaymentProcessor" ),
+                "PaymentService implements PaymentProcessor" );
+    }
+
+    @Test
+    public void testGetPackageSummary_NonExistentPackage()
+    {
+        PackageSummaryResponse result = service.getPackageSummary( "com.nonexistent.pkg", testProjectName );
+
+        assertNotNull( result );
+        assertEquals( 0, result.totalTypes() );
+        assertTrue( result.types().isEmpty() );
+    }
+
+    // -------------------------------------------------------------------------
+    // getPackageSummary — Javadoc extraction edge cases
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testGetPackageSummary_ClassWithoutJavadoc_ReturnsNull()
+    {
+        PackageSummaryResponse result = service.getPackageSummary( "com.example.javadoc", testProjectName );
+
+        var noDoc = result.types().stream()
+                .filter( t -> "NoDocClass".equals( t.simpleName() ) )
+                .findFirst()
+                .orElseThrow();
+        assertNull( noDoc.javadocSummary(),
+                "A class without Javadoc must return null, not a method's Javadoc" );
+    }
+
+    @Test
+    public void testGetPackageSummary_ClassWithMethodJavadocOnly_ReturnsNull()
+    {
+        PackageSummaryResponse result = service.getPackageSummary( "com.example.javadoc", testProjectName );
+
+        var methodDocOnly = result.types().stream()
+                .filter( t -> "MethodDocOnly".equals( t.simpleName() ) )
+                .findFirst()
+                .orElseThrow();
+        assertNull( methodDocOnly.javadocSummary(),
+                "A class without class-level Javadoc but with method Javadoc must return null" );
+    }
+
+    @Test
+    public void testGetPackageSummary_ClassWithMultiSentenceJavadoc_ReturnsFirstSentence()
+    {
+        PackageSummaryResponse result = service.getPackageSummary( "com.example.javadoc", testProjectName );
+
+        var multiSentence = result.types().stream()
+                .filter( t -> "MultiSentenceDoc".equals( t.simpleName() ) )
+                .findFirst()
+                .orElseThrow();
+        assertNotNull( multiSentence.javadocSummary() );
+        assertTrue( multiSentence.javadocSummary().endsWith( "." ),
+                "First sentence should end with a period: " + multiSentence.javadocSummary() );
+        assertFalse( multiSentence.javadocSummary().contains( "second sentence" ),
+                "Should only contain the first sentence" );
+    }
+
+    @Test
+    public void testGetPackageSummary_ClassWithTagOnlyJavadoc_ReturnsNull()
+    {
+        PackageSummaryResponse result = service.getPackageSummary( "com.example.javadoc", testProjectName );
+
+        var tagOnly = result.types().stream()
+                .filter( t -> "TagOnlyDoc".equals( t.simpleName() ) )
+                .findFirst()
+                .orElseThrow();
+        assertNull( tagOnly.javadocSummary(),
+                "A Javadoc with only @tags and no description should return null" );
+    }
+
+    @Test
+    public void testGetPackageSummary_ClassWithShortJavadocNoPeriod_ReturnsFullText()
+    {
+        PackageSummaryResponse result = service.getPackageSummary( "com.example.javadoc", testProjectName );
+
+        var shortDoc = result.types().stream()
+                .filter( t -> "ShortDocNoPeriod".equals( t.simpleName() ) )
+                .findFirst()
+                .orElseThrow();
+        assertNotNull( shortDoc.javadocSummary() );
+        assertEquals( "A utility without a period", shortDoc.javadocSummary() );
+    }
+
+    // -------------------------------------------------------------------------
+    // getWorkspaceOverview
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testGetWorkspaceOverview_FindsTestProject()
+    {
+        WorkspaceOverviewResponse result = service.getWorkspaceOverview( testProjectName, null );
+
+        assertNotNull( result );
+        assertTrue( result.totalProjects() >= 1 );
+        assertTrue( result.projects().stream()
+                .anyMatch( p -> testProjectName.equals( p.projectName() ) ) );
+    }
+
+    @Test
+    public void testGetWorkspaceOverview_ReportsPackagesAndTypes()
+    {
+        WorkspaceOverviewResponse result = service.getWorkspaceOverview( testProjectName, null );
+
+        var proj = result.projects().stream()
+                .filter( p -> testProjectName.equals( p.projectName() ) )
+                .findFirst()
+                .orElseThrow();
+        assertTrue( proj.packageCount() >= 2, "Should have com.example and com.example.payment" );
+        assertTrue( proj.typeCount() >= 3, "Should have at least PaymentService, PaymentProcessor, ErrorHandler" );
+    }
+
+    @Test
+    public void testGetWorkspaceOverview_PackageContainsTypeNames()
+    {
+        WorkspaceOverviewResponse result = service.getWorkspaceOverview( testProjectName, null );
+
+        var proj = result.projects().stream()
+                .filter( p -> testProjectName.equals( p.projectName() ) )
+                .findFirst()
+                .orElseThrow();
+
+        var paymentPkg = proj.packages().stream()
+                .filter( pkg -> "com.example.payment".equals( pkg.packageName() ) )
+                .findFirst()
+                .orElseThrow();
+        assertTrue( paymentPkg.typeNames().contains( "PaymentService" ) );
+        assertTrue( paymentPkg.typeNames().contains( "PaymentProcessor" ) );
+    }
+
+    @Test
+    public void testGetWorkspaceOverview_ProjectFilter()
+    {
+        WorkspaceOverviewResponse result = service.getWorkspaceOverview( "XyzNonExistent999", null );
+
+        assertNotNull( result );
+        assertEquals( 0, result.totalProjects() );
+    }
+
+    @Test
+    public void testGetWorkspaceOverview_MaxPackagesPerProject()
+    {
+        WorkspaceOverviewResponse result = service.getWorkspaceOverview( testProjectName, 1 );
+
+        var proj = result.projects().stream()
+                .filter( p -> testProjectName.equals( p.projectName() ) )
+                .findFirst()
+                .orElseThrow();
+        assertTrue( proj.packages().size() <= 1 );
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private void createPackageStructure() throws CoreException
+    {
+        createFolder( "src/com" );
+        createFolder( "src/com/example" );
+        createFolder( "src/com/example/payment" );
+        createFolder( "src/com/example/javadoc" );
+    }
+
+    private void createTestClasses() throws CoreException
+    {
+        String paymentProcessorSource =
+                "package com.example.payment;\n\n" +
+                "/**\n" +
+                " * Interface for processing payments.\n" +
+                " */\n" +
+                "public interface PaymentProcessor {\n" +
+                "    void processPayment(String orderId, double amount);\n" +
+                "}\n";
+        createFile( "src/com/example/payment/PaymentProcessor.java", paymentProcessorSource );
+
+        String paymentServiceSource =
+                "package com.example.payment;\n\n" +
+                "/**\n" +
+                " * Service that handles payment processing and error recovery.\n" +
+                " */\n" +
+                "public class PaymentService implements PaymentProcessor {\n" +
+                "    private int retryCount = 3;\n\n" +
+                "    @Override\n" +
+                "    public void processPayment(String orderId, double amount) {\n" +
+                "        System.out.println(\"Processing payment for order: \" + orderId);\n" +
+                "    }\n\n" +
+                "    public void handleError(Exception e) {\n" +
+                "        System.err.println(\"Payment error: \" + e.getMessage());\n" +
+                "    }\n" +
+                "}\n";
+        createFile( "src/com/example/payment/PaymentService.java", paymentServiceSource );
+
+        String errorHandlerSource =
+                "package com.example;\n\n" +
+                "/**\n" +
+                " * Generic error handler for the application.\n" +
+                " */\n" +
+                "public class ErrorHandler {\n" +
+                "    public void handleError(String context, Exception e) {\n" +
+                "        System.err.println(context + \": \" + e.getMessage());\n" +
+                "    }\n" +
+                "}\n";
+        createFile( "src/com/example/ErrorHandler.java", errorHandlerSource );
+
+        createJavadocTestClasses();
+    }
+
+    private void createFolder( String path ) throws CoreException
+    {
+        IFolder folder = project.getFolder( path );
+        if ( !folder.exists() )
+        {
+            folder.create( IResource.NONE, true, monitor );
+        }
+    }
+
+    private IFile createFile( String path, String content ) throws CoreException
+    {
+        IFile file = project.getFile( path );
+        if ( file.exists() )
+        {
+            file.setContents( new ByteArrayInputStream( content.getBytes() ), true, true, monitor );
+        }
+        else
+        {
+            file.create( new ByteArrayInputStream( content.getBytes() ), true, monitor );
+        }
+        return file;
+    }
+
+    private void createJavadocTestClasses() throws CoreException
+    {
+        String noDocSource =
+                "package com.example.javadoc;\n\n" +
+                "public class NoDocClass {\n" +
+                "    public void doSomething() {\n" +
+                "    }\n" +
+                "}\n";
+        createFile( "src/com/example/javadoc/NoDocClass.java", noDocSource );
+
+        String methodDocOnlySource =
+                "package com.example.javadoc;\n\n" +
+                "public class MethodDocOnly {\n" +
+                "    /**\n" +
+                "     * This Javadoc belongs to the method, not the class.\n" +
+                "     */\n" +
+                "    public void documented() {\n" +
+                "    }\n" +
+                "}\n";
+        createFile( "src/com/example/javadoc/MethodDocOnly.java", methodDocOnlySource );
+
+        String multiSentenceSource =
+                "package com.example.javadoc;\n\n" +
+                "/**\n" +
+                " * Handles complex multi-step transactions. This is the second sentence\n" +
+                " * which should not appear in the summary.\n" +
+                " */\n" +
+                "public class MultiSentenceDoc {\n" +
+                "}\n";
+        createFile( "src/com/example/javadoc/MultiSentenceDoc.java", multiSentenceSource );
+
+        String tagOnlySource =
+                "package com.example.javadoc;\n\n" +
+                "/**\n" +
+                " * @author someone\n" +
+                " * @since 1.0\n" +
+                " */\n" +
+                "public class TagOnlyDoc {\n" +
+                "}\n";
+        createFile( "src/com/example/javadoc/TagOnlyDoc.java", tagOnlySource );
+
+        String shortDocNoPeriodSource =
+                "package com.example.javadoc;\n\n" +
+                "/**\n" +
+                " * A utility without a period\n" +
+                " */\n" +
+                "public class ShortDocNoPeriod {\n" +
+                "}\n";
+        createFile( "src/com/example/javadoc/ShortDocNoPeriod.java", shortDocNoPeriodSource );
+    }
+}


### PR DESCRIPTION
Add four new tools to the eclipse-ide MCP server that address the 'cold start' discovery gap when an LLM needs to locate relevant code from a vague user query (e.g. 'Fix the error handling in the payment service').

The existing tools (findReferences, getTypeHierarchy, getMethodCallHierarchy) are excellent for precise structural navigation once you know which class to look at, but they require a fully qualified class name upfront. These new tools dramatically reduce the iterative exploration overhead:

New tools:
- searchTypes: Fuzzy type search via JDT SearchEngine. Supports wildcards (*Payment*), CamelCase (PS -> PaymentService), prefix, and package- qualified patterns. Equivalent to Eclipse's Open Type (Ctrl+Shift+T).
- searchMethods: Method name search with the same pattern support, plus optional declaring type filter.
- getPackageSummary: Returns each type's name, kind, Javadoc first sentence, method/field counts, and interfaces for a package — a table-of-contents in one call.
- getWorkspaceOverview: High-level architectural map of projects -> packages -> type names for immediate orientation.

Tool descriptions are written to guide LLM clients on when/why to call each tool, preferred workflow order, and how to translate user concepts into search patterns.

Implementation details:
- CodeDiscoveryService (mcp/services/) with bounded result collection
- Response records: TypeSearchResponse, MethodSearchResponse, PackageSummaryResponse, WorkspaceOverviewResponse
- CamelCase detection works for both uppercase (PS) and lowercase (pP) initial patterns
- Javadoc extraction uses type.getJavadocRange() to avoid picking up method-level docs on undocumented classes
- parseOptionalInt helper for graceful NumberFormatException handling
- PDE test with 28 test cases covering all tools and edge cases
- mcp-api.md regenerated