### PR TITLE
Silence noisy test output in headless environments

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/ConsoleService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/ConsoleService.java
@@ -250,11 +250,9 @@ public class ConsoleService
      * @throws PartInitException 
      */
     private MessageConsole findOrCreateConsole(String name) throws PartInitException {
-        // Get the console manager
         ConsolePlugin plugin = ConsolePlugin.getDefault();
         IConsoleManager conMan = plugin.getConsoleManager();
         
-        // Try to find the console
         IConsole[] existing = conMan.getConsoles();
         for (IConsole console : existing) {
             if (name.equals(console.getName()) && console instanceof MessageConsole messageConsole) {
@@ -262,17 +260,24 @@ public class ConsoleService
             }
         }
         
-        // No console found, create a new one
         MessageConsole newConsole = new MessageConsole(name, null);
         conMan.addConsoles(new IConsole[] { newConsole });
         
-        // Show the console view
-        var page = Optional.ofNullable( PlatformUI.getWorkbench() )
-                 .map( IWorkbench::getActiveWorkbenchWindow )
-                 .map( IWorkbenchWindow::getActivePage )
-                 .orElseThrow( () -> new PartInitException("No active page available") );
-            IConsoleView view = (IConsoleView) page.showView(IConsoleConstants.ID_CONSOLE_VIEW);
-            view.display(newConsole);
+        try
+        {
+            var page = Optional.ofNullable( PlatformUI.getWorkbench() )
+                     .map( IWorkbench::getActiveWorkbenchWindow )
+                     .map( IWorkbenchWindow::getActivePage );
+            if ( page.isPresent() )
+            {
+                IConsoleView view = (IConsoleView) page.get().showView(IConsoleConstants.ID_CONSOLE_VIEW);
+                view.display(newConsole);
+            }
+        }
+        catch ( PartInitException e )
+        {
+            // No UI available (headless/Tycho environment) — console still works for output
+        }
         
         return newConsole;
     }

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeAnalysisServicePDETest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeAnalysisServicePDETest.java
@@ -261,7 +261,6 @@ public class CodeAnalysisServicePDETest {
         
         // Verify markers were created
         IMarker[] markers = project.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
-        System.out.println("Found " + markers.length + " markers");
         
         // Skip if the Java builder didn't produce markers (e.g. in headless Tycho runner
         // without a full JDT workspace initialised)
@@ -273,8 +272,6 @@ public class CodeAnalysisServicePDETest {
                 testProjectName, 
                 "ALL", 
                 50);
-        
-        System.out.println("Compilation errors result: " + result);
         
         // Assert on the reported structure rather than on how it is worded.
         assertTrue(result.scope().contains(testProjectName));
@@ -303,15 +300,11 @@ public class CodeAnalysisServicePDETest {
                 "ERROR", 
                 50);
         
-        System.out.println("ERROR severity result: " + errorResult);
-        
         // Test getting only WARNING severity problems
         CompilationProblemsResponse warningResult = service.getCompilationErrors(
                 testProjectName, 
                 "WARNING", 
                 50);
-        
-        System.out.println("WARNING severity result: " + warningResult);
         
         // A severity filter must not leak the other severities into the counts. Whether
         // any warnings exist at all is environment-dependent, so only the filtering is
@@ -349,7 +342,6 @@ public class CodeAnalysisServicePDETest {
                 "No error markers generated - Java builder not active in this environment");
 
         CompilationProblemsResponse result = service.getCompilationErrors(testProjectName, "ALL", 50);
-        System.out.println("getCompilationErrors (with quick fixes) result:\n" + result);
 
         var problem = result.files().get(0).problems().get(0);
         assertTrue(problem.markerId() > 0, "executeQuickFix needs a marker id");
@@ -387,7 +379,6 @@ public class CodeAnalysisServicePDETest {
         // Obtain marker ID the same way an agent would: via getCompilationErrors.
         // No parsing - the id and the fix index are fields.
         CompilationProblemsResponse errorsResult = service.getCompilationErrors(testProjectName, "ALL", 50);
-        System.out.println("getCompilationErrors before apply:\n" + errorsResult);
         assertTrue(errorsResult.totalProblems() > 0, "Errors result must report a problem");
 
         long markerId = -1L;
@@ -414,7 +405,6 @@ public class CodeAnalysisServicePDETest {
         assertNotEquals(-1L, markerId, "Should have found a valid marker ID");
 
         QuickFixResponse applyResult = service.executeQuickFix(markerId, importIndex);
-        System.out.println("executeQuickFix result: " + applyResult);
 
         assertEquals(markerId, applyResult.markerId(), "the response names the marker it acted on");
         assertEquals(importIndex, applyResult.requestedIndex());
@@ -431,7 +421,6 @@ public class CodeAnalysisServicePDETest {
 
             file.refreshLocal(IResource.DEPTH_ZERO, monitor);
             String fileContent = new String(file.getContents(true).readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
-            System.out.println("File content after fix:\\n" + fileContent);
             assertTrue(fileContent.contains("import java.util.ArrayList"),
                     "File on disk should contain the added import after fix is applied. File content: " + fileContent);
         }
@@ -444,7 +433,6 @@ public class CodeAnalysisServicePDETest {
     @Test
     public void testExecuteQuickFix_UnknownMarkerId() {
         QuickFixResponse result = service.executeQuickFix(Long.MAX_VALUE, 0);
-        System.out.println("executeQuickFix (bad id) result: " + result);
 
         assertEquals(QuickFixResponse.Status.MARKER_NOT_FOUND, result.status());
         assertFalse(result.changedResource());

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeEditingServicePDETest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeEditingServicePDETest.java
@@ -235,8 +235,6 @@ public class CodeEditingServicePDETest {
         String replacementContent = "New Line A\nNew Line B";
         EditResult result = replaceLines("src/testFile.txt", replacementContent, 2, 4);
         
-        System.out.println( result );
-        
         // Read the updated file content
         String updatedContent = ResourceUtilities.readFileContent(testFile);
         
@@ -592,8 +590,6 @@ public class ApplicationNew {
 		 replaceLines("src/testFile.txt", replacement, startLine, endLine);
 		 
 		 String updatedContent = ResourceUtilities.readFileContent(testFile);
-		 System.out.println("------------");
-		 System.out.println(updatedContent);
 	}
     @Test
     public void testRefactorExtractTypeToNewFile() throws Exception

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/prompt/MarkdownParserPDETest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/prompt/MarkdownParserPDETest.java
@@ -166,7 +166,7 @@ public class MarkdownParserPDETest {
 				""";
         
         MarkdownParser parser = new MarkdownParser(prompt);
-        System.out.println(parser.parseToHtml());
+        parser.parseToHtml();
         
     }
     
@@ -178,7 +178,7 @@ public class MarkdownParserPDETest {
                 """;
         
         MarkdownParser parser = new MarkdownParser(prompt);
-        System.out.println(parser.parseToHtml());
+        parser.parseToHtml();
         
     }
     
@@ -197,8 +197,7 @@ public class MarkdownParserPDETest {
 ```
 """;
         MarkdownParser parser = new MarkdownParser( content );
-        var out = parser.parseToHtml();
-        System.out.println( out );
+        parser.parseToHtml();
     }
 
     


### PR DESCRIPTION
Tests should be silent on success. This removes debug prints and fixes a PartInitException that cluttered Maven/Tycho test output.

Changes:
- Remove System.out.println from CodeAnalysisServicePDETest (9 calls)
- Remove System.out.println from MarkdownParserPDETest (3 calls)
- Remove System.out.println from CodeEditingServicePDETest (2 calls)
- ConsoleService.findOrCreateConsole: gracefully handle missing UI instead of throwing PartInitException when no active workbench page is available (headless/Tycho environments)