### PR TITLE
Add chat history feature

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/chat/ChatHistoryRepository.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/chat/ChatHistoryRepository.java
@@ -1,0 +1,359 @@
+package com.github.gradusnikov.eclipse.assistai.chat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.e4.core.di.annotations.Creatable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.github.gradusnikov.eclipse.assistai.Activator;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+/**
+ * Persists and retrieves chat history sessions.
+ *
+ * <p>Each session is stored as a single JSON file under the plugin's state
+ * location ({@code .metadata/.plugins/<bundle-id>/history/}).  File names
+ * embed an ISO-like timestamp so a plain directory listing already comes back
+ * in chronological order.</p>
+ */
+@Creatable
+@Singleton
+public class ChatHistoryRepository
+{
+    private static final String    HISTORY_DIR      = "history";
+    private static final String    FILE_SUFFIX      = ".json";
+    private static final DateTimeFormatter TIMESTAMP_FMT =
+            DateTimeFormatter.ofPattern( "yyyyMMdd-HHmmss" );
+    private static final int       TITLE_MAX_LEN    = 60;
+
+    @Inject
+    private ILog logger;
+
+    /** The id of the session that is currently open in the view. */
+    private String currentSessionId;
+
+    private Path historyDir;
+
+    private final ObjectMapper mapper;
+
+    public ChatHistoryRepository()
+    {
+        mapper = new ObjectMapper();
+        mapper.enable( SerializationFeature.INDENT_OUTPUT );
+    }
+
+    @PostConstruct
+    public void init()
+    {
+        try
+        {
+            IPath statePath = Activator.getDefault().getStateLocation();
+            historyDir = statePath.toFile().toPath().resolve( HISTORY_DIR );
+            Files.createDirectories( historyDir );
+        }
+        catch ( Exception e )
+        {
+            logger.error( "Failed to initialise chat history directory", e );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    /**
+     * Persists the current conversation.  If the session was previously saved
+     * the existing file is overwritten; otherwise a new file is created.
+     *
+     * @param messages the live conversation messages
+     */
+    public void saveCurrentSession( List<ChatMessage> messages )
+    {
+        if ( messages == null || messages.isEmpty() )
+        {
+            return;
+        }
+        if ( currentSessionId == null )
+        {
+            currentSessionId = UUID.randomUUID().toString();
+        }
+        saveSession( currentSessionId, messages );
+    }
+
+    /** Forgets the current session id so the next save creates a fresh file. */
+    public void startNewSession()
+    {
+        currentSessionId = null;
+    }
+
+    /**
+     * Returns all saved sessions, most-recent first.
+     *
+     * @return an unmodifiable list of {@link ChatHistorySession} objects
+     */
+    public List<ChatHistorySession> listSessions()
+    {
+        if ( historyDir == null )
+        {
+            return Collections.emptyList();
+        }
+        File dir = historyDir.toFile();
+        File[] files = dir.listFiles( f -> f.isFile() && f.getName().endsWith( FILE_SUFFIX ) );
+        if ( files == null || files.length == 0 )
+        {
+            return Collections.emptyList();
+        }
+
+        // Sort descending by file name (timestamp prefix guarantees correct order)
+        Arrays.sort( files, ( a, b ) -> b.getName().compareTo( a.getName() ) );
+
+        List<ChatHistorySession> sessions = new ArrayList<>();
+        for ( File f : files )
+        {
+            try
+            {
+                ChatHistorySession session = mapper.readValue( f, ChatHistorySession.class );
+                sessions.add( session );
+            }
+            catch ( IOException e )
+            {
+                logger.error( "Failed to read history file: " + f.getName(), e );
+            }
+        }
+        return Collections.unmodifiableList( sessions );
+    }
+
+    /**
+     * Deletes the history file for the given session id.
+     *
+     * @param sessionId the id of the session to delete
+     */
+    public void deleteSession( String sessionId )
+    {
+        if ( historyDir == null || sessionId == null )
+        {
+            return;
+        }
+        File dir = historyDir.toFile();
+        File[] files = dir.listFiles( f -> f.isFile() && f.getName().endsWith( FILE_SUFFIX ) );
+        if ( files == null )
+        {
+            return;
+        }
+        for ( File f : files )
+        {
+            try
+            {
+                ChatHistorySession session = mapper.readValue( f, ChatHistorySession.class );
+                if ( sessionId.equals( session.id() ) )
+                {
+                    f.delete();
+                    if ( sessionId.equals( currentSessionId ) )
+                    {
+                        currentSessionId = null;
+                    }
+                    return;
+                }
+            }
+            catch ( IOException e )
+            {
+                logger.error( "Failed to read history file while deleting: " + f.getName(), e );
+            }
+        }
+    }
+
+    /**
+     * Marks the given session as the currently-open one so subsequent
+     * auto-saves update that file rather than creating a new one.
+     *
+     * @param sessionId the session to resume
+     */
+    public void setCurrentSession( String sessionId )
+    {
+        this.currentSessionId = sessionId;
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    private void saveSession( String sessionId, List<ChatMessage> messages )
+    {
+        if ( historyDir == null )
+        {
+            return;
+        }
+        try
+        {
+            // Build DTO
+            List<PersistedMessage> persisted = new ArrayList<>();
+            for ( ChatMessage msg : messages )
+            {
+                if ( msg.isEmpty() )
+                {
+                    continue;
+                }
+                List<PersistedAttachment> attachments = new ArrayList<>();
+                for ( Attachment att : msg.getAttachments() )
+                {
+                    if ( att instanceof Attachment.FileContentAttachment fca )
+                    {
+                        attachments.add( new PersistedAttachment(
+                                "file",
+                                fca.getFileName(),
+                                fca.getLineNumberStart(),
+                                fca.getLineNumberEnd(),
+                                fca.getSelectedContent() ) );
+                    }
+                    // ImageAttachment is not persisted (binary data too large)
+                }
+                persisted.add( new PersistedMessage(
+                        msg.getId(),
+                        msg.getRole(),
+                        msg.getName(),
+                        msg.getContent(),
+                        attachments ) );
+            }
+
+            String title       = buildTitle( messages );
+            String createdAt   = findOrCreateTimestamp( sessionId );
+            ChatHistorySession session = new ChatHistorySession( sessionId, createdAt, title, persisted );
+
+            String json   = mapper.writeValueAsString( session );
+            Path   target = resolveFilePath( sessionId, createdAt );
+            Files.writeString( target, json, StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING );
+        }
+        catch ( IOException e )
+        {
+            logger.error( "Failed to save chat history session", e );
+        }
+    }
+
+    /** Derives the file path from the session id and timestamp. */
+    private Path resolveFilePath( String sessionId, String createdAt )
+    {
+        // File name: <timestamp>_<sessionId>.json
+        String filename = createdAt + "_" + sessionId + FILE_SUFFIX;
+        return historyDir.resolve( filename );
+    }
+
+    /**
+     * Returns the timestamp for an existing session file, or creates a fresh
+     * one when the session is new.
+     */
+    private String findOrCreateTimestamp( String sessionId )
+    {
+        if ( historyDir == null )
+        {
+            return LocalDateTime.now().format( TIMESTAMP_FMT );
+        }
+        File dir = historyDir.toFile();
+        File[] files = dir.listFiles( f -> f.isFile() && f.getName().contains( sessionId ) );
+        if ( files != null )
+        {
+            for ( File f : files )
+            {
+                // Extract timestamp prefix from file name
+                String name = f.getName();
+                int sep = name.indexOf( '_' );
+                if ( sep > 0 )
+                {
+                    return name.substring( 0, sep );
+                }
+            }
+        }
+        return LocalDateTime.now().format( TIMESTAMP_FMT );
+    }
+
+    /** Builds a human-readable session title from the first user message. */
+    private String buildTitle( List<ChatMessage> messages )
+    {
+        return messages.stream()
+                       .filter( m -> "user".equals( m.getRole() ) )
+                       .map( ChatMessage::getContent )
+                       .filter( c -> c != null && !c.isBlank() )
+                       .findFirst()
+                       .map( c -> c.lines().findFirst().orElse( c ) )
+                       .map( c -> c.length() > TITLE_MAX_LEN ? c.substring( 0, TITLE_MAX_LEN ) + "…" : c )
+                       .orElse( "(empty)" );
+    }
+
+    // -------------------------------------------------------------------------
+    // Data model (DTOs)
+    // -------------------------------------------------------------------------
+
+    /**
+     * A complete serialised chat session.
+     *
+     * @param id        stable UUID for this session
+     * @param createdAt timestamp string used as file-name prefix
+     * @param title     human-readable summary (first user message, truncated)
+     * @param messages  ordered list of messages
+     */
+    @JsonIgnoreProperties( ignoreUnknown = true )
+    public record ChatHistorySession(
+            String id,
+            String createdAt,
+            String title,
+            List<PersistedMessage> messages )
+    {
+    }
+
+    /**
+     * A single message within a persisted session.
+     *
+     * @param id      original message UUID
+     * @param role    "user" | "assistant" | "system" | "tool"
+     * @param name    optional name field
+     * @param content plain-text / markdown content
+     * @param attachments file attachments (images are not persisted)
+     */
+    @JsonIgnoreProperties( ignoreUnknown = true )
+    public record PersistedMessage(
+            String id,
+            String role,
+            String name,
+            String content,
+            List<PersistedAttachment> attachments )
+    {
+    }
+
+    /**
+     * A persisted file-content attachment.
+     *
+     * @param type            always "file"
+     * @param filePath        workspace-relative path
+     * @param lineNumberStart start line (1-based, 0 if unknown)
+     * @param lineNumberEnd   end line (1-based, 0 if unknown)
+     * @param selectedContent the captured text
+     */
+    @JsonIgnoreProperties( ignoreUnknown = true )
+    public record PersistedAttachment(
+            String type,
+            String filePath,
+            int lineNumberStart,
+            int lineNumberEnd,
+            String selectedContent )
+    {
+    }
+}

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/view/ChatHistoryDialog.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/view/ChatHistoryDialog.java
@@ -1,0 +1,379 @@
+package com.github.gradusnikov.eclipse.assistai.view;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.layout.TableColumnLayout;
+import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.ColumnWeightData;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.TableViewerColumn;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.SashForm;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+
+import com.github.gradusnikov.eclipse.assistai.chat.ChatHistoryRepository.ChatHistorySession;
+import com.github.gradusnikov.eclipse.assistai.chat.ChatHistoryRepository.PersistedMessage;
+
+/**
+ * A dialog that lets the user browse, preview, load or delete past chat
+ * sessions.
+ *
+ * <p>Layout: a horizontal {@link SashForm} with a session list on the left and
+ * a read-only text preview on the right.  Three custom buttons sit in the
+ * button bar: <em>Load</em>, <em>Delete</em> and <em>Close</em>.</p>
+ */
+public class ChatHistoryDialog extends Dialog
+{
+    // Button ids
+    private static final int LOAD_ID   = IDialogConstants.CLIENT_ID + 1;
+    private static final int DELETE_ID = IDialogConstants.CLIENT_ID + 2;
+
+    private static final DateTimeFormatter STORED_FMT  =
+            DateTimeFormatter.ofPattern( "yyyyMMdd-HHmmss" );
+    private static final DateTimeFormatter DISPLAY_FMT =
+            DateTimeFormatter.ofPattern( "yyyy-MM-dd  HH:mm:ss" );
+
+    private static final int PREVIEW_MAX_CHARS = 2000;
+
+    private final List<ChatHistorySession> sessions;
+
+    private TableViewer tableViewer;
+    private Text        previewText;
+
+    /** The session the user confirmed with Load, or {@code null}. */
+    private ChatHistorySession selectedSession;
+
+    /**
+     * @param parentShell the shell to attach this dialog to
+     * @param sessions    all sessions to display (most-recent first)
+     */
+    public ChatHistoryDialog( Shell parentShell, List<ChatHistorySession> sessions )
+    {
+        super( parentShell );
+        this.sessions = sessions;
+        setShellStyle( getShellStyle() | SWT.RESIZE );
+    }
+
+    @Override
+    protected void configureShell( Shell shell )
+    {
+        super.configureShell( shell );
+        shell.setText( "Chat History" );
+        shell.setMinimumSize( 700, 450 );
+    }
+
+    // -------------------------------------------------------------------------
+    // UI construction
+    // -------------------------------------------------------------------------
+
+    @Override
+    protected Control createDialogArea( Composite parent )
+    {
+        Composite area = (Composite) super.createDialogArea( parent );
+        GridLayout layout = new GridLayout( 1, false );
+        layout.marginWidth  = 8;
+        layout.marginHeight = 8;
+        area.setLayout( layout );
+
+        SashForm sash = new SashForm( area, SWT.HORIZONTAL );
+        sash.setLayoutData( new GridData( SWT.FILL, SWT.FILL, true, true ) );
+
+        createSessionList( sash );
+        createPreviewPanel( sash );
+
+        sash.setWeights( new int[]{ 40, 60 } );
+
+        // Populate with data and select the first row
+        tableViewer.setInput( sessions );
+        if ( !sessions.isEmpty() )
+        {
+            tableViewer.getTable().select( 0 );
+            updatePreview( sessions.get( 0 ) );
+        }
+        updateButtons();
+
+        return area;
+    }
+
+    /** Builds the session table on the left side of the sash. */
+    private void createSessionList( Composite parent )
+    {
+        Composite listPanel = new Composite( parent, SWT.NONE );
+        TableColumnLayout colLayout = new TableColumnLayout();
+        listPanel.setLayout( colLayout );
+
+        tableViewer = new TableViewer( listPanel,
+                SWT.BORDER | SWT.FULL_SELECTION | SWT.SINGLE | SWT.V_SCROLL );
+        tableViewer.getTable().setHeaderVisible( true );
+        tableViewer.getTable().setLinesVisible( true );
+
+        // Column: date
+        TableViewerColumn dateCol = new TableViewerColumn( tableViewer, SWT.NONE );
+        dateCol.getColumn().setText( "Date" );
+        dateCol.setLabelProvider( new ColumnLabelProvider()
+        {
+            @Override
+            public String getText( Object element )
+            {
+                if ( element instanceof ChatHistorySession s )
+                {
+                    return formatTimestamp( s.createdAt() );
+                }
+                return "";
+            }
+        } );
+        colLayout.setColumnData( dateCol.getColumn(), new ColumnWeightData( 35, 130, true ) );
+
+        // Column: title
+        TableViewerColumn titleCol = new TableViewerColumn( tableViewer, SWT.NONE );
+        titleCol.getColumn().setText( "Session" );
+        titleCol.setLabelProvider( new ColumnLabelProvider()
+        {
+            @Override
+            public String getText( Object element )
+            {
+                if ( element instanceof ChatHistorySession s )
+                {
+                    return s.title();
+                }
+                return "";
+            }
+        } );
+        colLayout.setColumnData( titleCol.getColumn(), new ColumnWeightData( 50, 150, true ) );
+
+        // Column: message count
+        TableViewerColumn countCol = new TableViewerColumn( tableViewer, SWT.RIGHT );
+        countCol.getColumn().setText( "Msgs" );
+        countCol.setLabelProvider( new ColumnLabelProvider()
+        {
+            @Override
+            public String getText( Object element )
+            {
+                if ( element instanceof ChatHistorySession s )
+                {
+                    return String.valueOf( s.messages() == null ? 0 : s.messages().size() );
+                }
+                return "0";
+            }
+        } );
+        colLayout.setColumnData( countCol.getColumn(), new ColumnWeightData( 15, 50, true ) );
+
+        tableViewer.setContentProvider( ArrayContentProvider.getInstance() );
+
+        // Update preview and button state on selection change
+        tableViewer.addSelectionChangedListener( event -> {
+            ChatHistorySession s = getSelectedSession();
+            updatePreview( s );
+            updateButtons();
+        } );
+
+        // Double-click loads the session immediately
+        tableViewer.addDoubleClickListener( event -> {
+            if ( getSelectedSession() != null )
+            {
+                buttonPressed( LOAD_ID );
+            }
+        } );
+    }
+
+    /** Builds the read-only preview text area on the right side. */
+    private void createPreviewPanel( Composite parent )
+    {
+        Composite panel = new Composite( parent, SWT.NONE );
+        panel.setLayout( new GridLayout( 1, false ) );
+
+        previewText = new Text( panel,
+                SWT.BORDER | SWT.MULTI | SWT.READ_ONLY | SWT.WRAP | SWT.V_SCROLL );
+        previewText.setLayoutData( new GridData( SWT.FILL, SWT.FILL, true, true ) );
+        previewText.setBackground( panel.getDisplay().getSystemColor( SWT.COLOR_LIST_BACKGROUND ) );
+    }
+
+    // -------------------------------------------------------------------------
+    // Button bar
+    // -------------------------------------------------------------------------
+
+    @Override
+    protected void createButtonsForButtonBar( Composite parent )
+    {
+        createButton( parent, LOAD_ID,   "Load",   true  );
+        createButton( parent, DELETE_ID, "Delete", false );
+        createButton( parent, IDialogConstants.CANCEL_ID, IDialogConstants.CLOSE_LABEL, false );
+    }
+
+    @Override
+    protected void buttonPressed( int buttonId )
+    {
+        if ( buttonId == LOAD_ID )
+        {
+            selectedSession = getSelectedSession();
+            setReturnCode( OK );
+            close();
+        }
+        else if ( buttonId == DELETE_ID )
+        {
+            ChatHistorySession s = getSelectedSession();
+            if ( s != null && confirmDelete( s ) )
+            {
+                sessions.remove( s );
+                tableViewer.refresh();
+                // Select next row if available
+                int count = tableViewer.getTable().getItemCount();
+                if ( count > 0 )
+                {
+                    tableViewer.getTable().select( 0 );
+                    updatePreview( sessions.isEmpty() ? null : sessions.get( 0 ) );
+                }
+                else
+                {
+                    updatePreview( null );
+                }
+                updateButtons();
+                // Propagate deletion to caller via return code trick:
+                // we set a special return code so the presenter knows
+                // a deletion occurred even if no Load was pressed.
+                setReturnCode( IDialogConstants.INTERNAL_ID );
+            }
+        }
+        else
+        {
+            super.buttonPressed( buttonId );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Returns the currently highlighted session, or {@code null}. */
+    ChatHistorySession getSelectedSession()
+    {
+        IStructuredSelection sel = tableViewer.getStructuredSelection();
+        if ( sel.isEmpty() )
+        {
+            return null;
+        }
+        Object first = sel.getFirstElement();
+        return first instanceof ChatHistorySession s ? s : null;
+    }
+
+    /**
+     * Returns the session the user loaded, or {@code null} when the dialog was
+     * closed without loading.
+     */
+    public ChatHistorySession getLoadedSession()
+    {
+        return selectedSession;
+    }
+
+    /**
+     * Returns a snapshot of the session list at the time the dialog was closed.
+     * The presenter uses this to perform any deletions the user requested.
+     */
+    public List<ChatHistorySession> getRemainingSessionIds()
+    {
+        return sessions;
+    }
+
+    private void updateButtons()
+    {
+        boolean hasSelection = getSelectedSession() != null;
+        setButtonState( LOAD_ID,   hasSelection );
+        setButtonState( DELETE_ID, hasSelection );
+    }
+
+    private void setButtonState( int buttonId, boolean enabled )
+    {
+        var btn = getButton( buttonId );
+        if ( btn != null )
+        {
+            btn.setEnabled( enabled );
+        }
+    }
+
+    /** Renders a plain-text transcript of the session into the preview area. */
+    private void updatePreview( ChatHistorySession session )
+    {
+        if ( previewText == null || previewText.isDisposed() )
+        {
+            return;
+        }
+        if ( session == null || session.messages() == null || session.messages().isEmpty() )
+        {
+            previewText.setText( "(no messages)" );
+            return;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        int totalChars = 0;
+
+        for ( PersistedMessage msg : session.messages() )
+        {
+            if ( msg.content() == null || msg.content().isBlank() )
+            {
+                continue;
+            }
+            String label = "user".equals( msg.role() ) ? "You" : "Assistant";
+            String line  = "── " + label + " ─────────────────────────────────────────────\n";
+            sb.append( line );
+
+            String content = msg.content();
+            int remaining  = PREVIEW_MAX_CHARS - totalChars;
+            if ( remaining <= 0 )
+            {
+                sb.append( "  [… more messages not shown]\n" );
+                break;
+            }
+            if ( content.length() > remaining )
+            {
+                sb.append( content, 0, remaining ).append( "…\n" );
+                totalChars += remaining;
+            }
+            else
+            {
+                sb.append( content ).append( "\n" );
+                totalChars += content.length();
+            }
+            sb.append( "\n" );
+        }
+
+        previewText.setText( sb.toString() );
+    }
+
+    private boolean confirmDelete( ChatHistorySession session )
+    {
+        return MessageDialog.openConfirm(
+                getShell(),
+                "Delete Session",
+                "Delete session \"" + session.title() + "\"?\n\nThis cannot be undone." );
+    }
+
+    private String formatTimestamp( String raw )
+    {
+        if ( raw == null )
+        {
+            return "";
+        }
+        try
+        {
+            LocalDateTime dt = LocalDateTime.parse( raw, STORED_FMT );
+            return dt.format( DISPLAY_FMT );
+        }
+        catch ( DateTimeParseException e )
+        {
+            return raw;
+        }
+    }
+}

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/view/ChatView.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/view/ChatView.java
@@ -25,6 +25,8 @@ import org.eclipse.jface.fieldassist.TextContentAdapter;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.browser.BrowserFunction;
+import org.eclipse.swt.browser.ProgressAdapter;
+import org.eclipse.swt.browser.ProgressEvent;
 import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.dnd.Clipboard;
@@ -63,7 +65,9 @@ import org.eclipse.ui.PlatformUI;
 
 import com.github.gradusnikov.eclipse.assistai.chat.Attachment;
 import com.github.gradusnikov.eclipse.assistai.chat.Attachment.UiVisitor;
+import com.github.gradusnikov.eclipse.assistai.chat.ChatMessage;
 import com.github.gradusnikov.eclipse.assistai.models.ModelApiDescriptor;
+import com.github.gradusnikov.eclipse.assistai.prompt.ChatMessageUtilities;
 import com.github.gradusnikov.eclipse.assistai.prompt.MarkdownParser;
 import com.github.gradusnikov.eclipse.assistai.tools.AssistaiSharedFiles;
 import com.github.gradusnikov.eclipse.assistai.tools.AssistaiSharedFonts;
@@ -211,6 +215,7 @@ public class ChatView
         
         // Add toolbar items instead of buttons
         modelDropdownItem = createModelSelectorComposite(actionToolBar);
+        createHistoryToolItem(actionToolBar);
         createAttachmentToolItem(actionToolBar);
         createReplayToolItem(actionToolBar);
         createClearChatToolItem(actionToolBar);
@@ -449,6 +454,35 @@ public class ChatView
         return item;
     }
     
+    /**
+     * Creates a toolbar item that opens the chat history dialog.
+     *
+     * @param toolbar The parent toolbar
+     * @return The created toolbar item
+     */
+    private ToolItem createHistoryToolItem(ToolBar toolbar) {
+        ToolItem item = new ToolItem(toolbar, SWT.PUSH);
+
+        try {
+            // Use the back arrow icon to suggest "previous conversations"
+            Image historyIcon = PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_TOOL_BACK);
+            item.setImage(historyIcon);
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+        }
+
+        item.setToolTipText("Chat history");
+
+        item.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                presenter.onShowHistory();
+            }
+        });
+
+        return item;
+    }
+
     /**
      * Creates a toolbar item that allows the user to replay the last conversation
      * using a different model.
@@ -1429,4 +1463,46 @@ public class ChatView
 	               .replace("\r", "\\r")
 	               .replace("\t", "\\t");
 	}
+
+    /**
+     * Clears the browser and re-renders a list of messages.
+     *
+     * <p>The method resets the browser to a blank page first, then waits for
+     * the page to finish loading before appending each message.  This avoids
+     * race conditions where DOM operations run before the HTML scaffold exists.</p>
+     *
+     * @param messages the ordered list of messages to render
+     */
+    public void renderConversation( List<ChatMessage> messages )
+    {
+        uiSync.asyncExec( () -> {
+            // Re-initialise the browser with the base HTML/CSS/JS scaffold
+            initializeChatView( browser );
+
+            // Once the page finishes loading, inject all the messages
+            browser.addProgressListener( new ProgressAdapter()
+            {
+                @Override
+                public void completed( ProgressEvent event )
+                {
+                    // Remove this one-shot listener immediately
+                    browser.removeProgressListener( this );
+
+                    for ( ChatMessage msg : messages )
+                    {
+                        if ( msg.isEmpty() )
+                        {
+                            continue;
+                        }
+                        // appendMessage and setMessageHtml already call uiSync.asyncExec
+                        // internally, so the calls queue up in order on the UI thread.
+                        appendMessage( msg.getId(), msg.getRole() );
+                        String content = ChatMessageUtilities.toMarkdownContent( msg );
+                        setMessageHtml( msg.getId(), content );
+                    }
+                }
+            } );
+        } );
+    }
+
 }

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/view/ChatViewPresenter.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/view/ChatViewPresenter.java
@@ -29,6 +29,7 @@ import org.eclipse.core.runtime.jobs.IJobManager;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.e4.core.di.annotations.Creatable;
 import org.eclipse.e4.ui.di.UISynchronize;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.wizard.Wizard;
@@ -42,6 +43,7 @@ import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageLoader;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.FileDialog;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -51,6 +53,9 @@ import org.eclipse.ui.dialogs.WizardNewFileCreationPage;
 import com.github.gradusnikov.eclipse.assistai.Activator;
 import com.github.gradusnikov.eclipse.assistai.chat.Attachment;
 import com.github.gradusnikov.eclipse.assistai.chat.Attachment.FileContentAttachment;
+import com.github.gradusnikov.eclipse.assistai.chat.ChatHistoryRepository;
+import com.github.gradusnikov.eclipse.assistai.chat.ChatHistoryRepository.ChatHistorySession;
+import com.github.gradusnikov.eclipse.assistai.chat.ChatHistoryRepository.PersistedMessage;
 import com.github.gradusnikov.eclipse.assistai.chat.ChatMessage;
 import com.github.gradusnikov.eclipse.assistai.chat.Conversation;
 import com.github.gradusnikov.eclipse.assistai.jobs.AssistAIJobConstants;
@@ -69,6 +74,7 @@ import com.github.gradusnikov.eclipse.assistai.tools.ResourceUtilities;
 import com.github.gradusnikov.eclipse.assistai.view.ChatView.NotificationType;
 
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
@@ -97,28 +103,30 @@ public class ChatViewPresenter implements IResourceCacheListener
 
     @Inject
     private AppendMessageToViewSubscriber appendMessageToViewSubscriber;
-    
+
     @Inject
     private ApplyPatchWizardHelper        applyPatchWizzardHelper;
-    
+
     @Inject
-    private CodeEditingService codeEditingService;
-    
+    private CodeEditingService            codeEditingService;
+
     @Inject
-    private ModelApiDescriptorRepository modelReposotiry;
-    
+    private ModelApiDescriptorRepository  modelReposotiry;
+
     @Inject
-    private PromptRepository promptRepository;
-    
+    private PromptRepository              promptRepository;
+
     @Inject
-    private UISynchronize uiSync;
-    
+    private UISynchronize                 uiSync;
+
     @Inject
-    private ResourceCache resourceCache;
-    
-    
-    private IPreferenceStore preferences;
-    
+    private ResourceCache                 resourceCache;
+
+    @Inject
+    private ChatHistoryRepository         historyRepository;
+
+    private IPreferenceStore              preferences;
+
     private static final String           LAST_SELECTED_DIR_KEY = "lastSelectedDirectory";
 
     private final List<Attachment>        attachments           = new ArrayList<>();
@@ -127,40 +135,48 @@ public class ChatViewPresenter implements IResourceCacheListener
     public void init()
     {
         preferences = Activator.getDefault().getPreferenceStore();
-    	appendMessageToViewSubscriber.setPresenter( this );
-        resourceCache.addCacheListener(this);
-        
+        appendMessageToViewSubscriber.setPresenter( this );
+        resourceCache.addCacheListener( this );
         initializeAvailableModels();
     }
-    
-    @Override
-    public void cacheChanged(ResourceCacheEvent event)
+
+    /** Flush the current session to disk when the workbench shuts down. */
+    @PreDestroy
+    public void destroy()
     {
-        if (event.getType() == ResourceCacheEvent.Type.ADDED && event.getResource() != null)
+        historyRepository.saveCurrentSession( conversation.messages() );
+    }
+
+    @Override
+    public void cacheChanged( ResourceCacheEvent event )
+    {
+        if ( event.getType() == ResourceCacheEvent.Type.ADDED && event.getResource() != null )
         {
             String resourceName = event.getResource().descriptor().displayName();
-            applyToView(view -> {
+            applyToView( view -> {
                 view.showNotification(
                     "Resource added: " + resourceName,
-                    Duration.ofSeconds(3),
-                    NotificationType.INFO
-                );
-            });
+                    Duration.ofSeconds( 3 ),
+                    NotificationType.INFO );
+            } );
         }
     }
 
-	private void initializeAvailableModels() {
-		// Initialize model from preferences if available
+    private void initializeAvailableModels()
+    {
         var selectedModel = modelReposotiry.getChatModelInUse();
-        var models = modelReposotiry.listModelApiDescriptors();
+        var models        = modelReposotiry.listModelApiDescriptors();
         applyToView( view -> {
-        	view.setAvailableModels( models, Optional.ofNullable( selectedModel.uid() ).orElse("" ) );
-        });
-	}
+            view.setAvailableModels( models, Optional.ofNullable( selectedModel.uid() ).orElse( "" ) );
+        } );
+    }
 
     public void onClear()
     {
         onStop();
+        // Persist the current conversation before wiping it
+        historyRepository.saveCurrentSession( conversation.messages() );
+        historyRepository.startNewSession();
         conversation.clear();
         attachments.clear();
         resourceCache.clear();
@@ -190,24 +206,23 @@ public class ChatViewPresenter implements IResourceCacheListener
 
     private ChatMessage createUserMessage( String userMessage )
     {
-        Pattern commandPattern = Pattern.compile("^/(\\S+)");
+        Pattern commandPattern = Pattern.compile( "^/(\\S+)" );
         Matcher commandMatcher = commandPattern.matcher( userMessage );
         Supplier<String> supplier = () -> userMessage;
         if ( commandMatcher.find() )
         {
             supplier = () -> promptRepository.findPromptByCommandName( commandMatcher.group( 1 ) )
                                              .map( chatMessageFactory::createUserChatMessage )
-                                             .map( ChatMessage::getContent)
+                                             .map( ChatMessage::getContent )
                                              .orElse( userMessage );
         }
-        
         ChatMessage message = chatMessageFactory.createUserChatMessage( supplier );
         message.setAttachments( attachments );
         return message;
     }
 
-
-	public ChatMessage beginFunctionCallMessage() {
+    public ChatMessage beginFunctionCallMessage()
+    {
         ChatMessage message = chatMessageFactory.createAssistantChatMessage( "" );
         // DO NOT ADD IT TO CONVERSATION
         applyToView( messageView -> {
@@ -215,9 +230,9 @@ public class ChatViewPresenter implements IResourceCacheListener
             messageView.setInputEnabled( false );
         } );
         return message;
-	}
+    }
 
-	public ChatMessage beginMessageFromAssistant()
+    public ChatMessage beginMessageFromAssistant()
     {
         ChatMessage message = chatMessageFactory.createAssistantChatMessage( "" );
         conversation.add( message );
@@ -237,36 +252,35 @@ public class ChatViewPresenter implements IResourceCacheListener
 
     public void endMessageFromAssistant( ChatMessage message )
     {
-    	applyToView( messageView -> {
+        applyToView( messageView -> {
             messageView.setInputEnabled( true );
             messageView.setFocus();
             if ( message.getContent().isBlank() )
             {
-            	conversation.removeMessageById(message.getId());
-            	messageView.removeMessage(message.getId());
+                conversation.removeMessageById( message.getId() );
+                messageView.removeMessage( message.getId() );
             }
+            // Auto-save after every completed assistant turn
+            historyRepository.saveCurrentSession( conversation.messages() );
         } );
     }
-    
+
     public void hideMessage( String messageId )
     {
         applyToView( messageView -> {
-            messageView.hideMessage(messageId);
+            messageView.hideMessage( messageId );
         } );
     }
-    
-    
-    
+
     /**
-     * Cancels all running ChatGPT jobs
+     * Cancels all running ChatGPT jobs.
      */
     public void onStop()
     {
         var jobs = jobManager.find( null );
         Arrays.stream( jobs )
-        	  .filter( job -> job.getName().startsWith( AssistAIJobConstants.JOB_PREFIX ) )
-        	  .forEach( Job::cancel );
-
+              .filter( job -> job.getName().startsWith( AssistAIJobConstants.JOB_PREFIX ) )
+              .forEach( Job::cancel );
         applyToView( messageView -> {
             messageView.setInputEnabled( true );
         } );
@@ -275,34 +289,28 @@ public class ChatViewPresenter implements IResourceCacheListener
     /**
      * Copies the given code block to the system clipboard.
      *
-     * @param codeBlock
-     *            The code block to be copied to the clipboard.
+     * @param codeBlock the code block to copy
      */
     public void onCopyCode( String codeBlock )
     {
-        var clipboard = new Clipboard( PlatformUI.getWorkbench().getDisplay() );
+        var clipboard    = new Clipboard( PlatformUI.getWorkbench().getDisplay() );
         var textTransfer = TextTransfer.getInstance();
-        clipboard.setContents( new Object[] { codeBlock }, new Transfer[] { textTransfer } );
+        clipboard.setContents( new Object[]{ codeBlock }, new Transfer[]{ textTransfer } );
         clipboard.dispose();
     }
 
     public void onApplyPatch( String codeBlock )
     {
         applyPatchWizzardHelper.showApplyPatchWizardDialog( codeBlock, null );
-
     }
 
     public void onSendPredefinedPrompt( Prompts type, ChatMessage message )
     {
         conversation.add( message );
-
-        // update view
         applyToView( messageView -> {
             messageView.appendMessage( message.getId(), message.getRole() );
             messageView.setMessageHtml( message.getId(), "/" + type.getCommandName() );
         } );
-
-        // schedule message
         sendConversationJobProvider.get().schedule();
     }
 
@@ -314,26 +322,20 @@ public class ChatViewPresenter implements IResourceCacheListener
             logger.error( "No active display" );
             return;
         }
-        
+
         uiSync.asyncExec( () -> {
             FileDialog fileDialog = new FileDialog( display.getActiveShell(), SWT.OPEN );
             fileDialog.setText( "Select an Image" );
-
-            // Retrieve the last selected directory from the preferences
             String lastSelectedDirectory = preferences.getString( LAST_SELECTED_DIR_KEY );
             fileDialog.setFilterPath( lastSelectedDirectory );
-
-            fileDialog.setFilterExtensions( new String[] { "*.png", "*.jpeg", "*.jpg" } );
-            fileDialog.setFilterNames( new String[] { "PNG files (*.png)", "JPEG files (*.jpeg, *.jpg)" } );
+            fileDialog.setFilterExtensions( new String[]{ "*.png", "*.jpeg", "*.jpg" } );
+            fileDialog.setFilterNames( new String[]{ "PNG files (*.png)", "JPEG files (*.jpeg, *.jpg)" } );
 
             String selectedFilePath = fileDialog.open();
-
             if ( selectedFilePath != null )
             {
-                // Save the last selected directory back to the preferences
                 String newLastSelectedDirectory = new File( selectedFilePath ).getParent();
                 preferences.putValue( LAST_SELECTED_DIR_KEY, newLastSelectedDirectory );
-
                 ImageData[] imageDataArray = new ImageLoader().load( selectedFilePath );
                 if ( imageDataArray.length > 0 )
                 {
@@ -350,7 +352,7 @@ public class ChatViewPresenter implements IResourceCacheListener
     {
         uiSync.asyncExec( () -> {
             partAccessor.findMessageView().ifPresent( consumer );
-        });
+        } );
     }
 
     public void onImageSelected( Image image )
@@ -374,255 +376,331 @@ public class ChatViewPresenter implements IResourceCacheListener
         } );
     }
 
-
-    public void onInsertCode(String codeBlock) {
-       uiSync.asyncExec(() -> {
-            try 
-            {
-                Optional.ofNullable(PlatformUI.getWorkbench())
-                    .map(workbench -> workbench.getActiveWorkbenchWindow())
-                    .map(window -> window.getActivePage())
-                    .map(page -> page.getActiveEditor())
-                    .flatMap(editor -> Optional.ofNullable(editor.getAdapter(org.eclipse.ui.texteditor.ITextEditor.class)))
-                    .ifPresent(textEditor -> {
-                        var selectionProvider = textEditor.getSelectionProvider();
-                        var document = textEditor.getDocumentProvider()
-                                                 .getDocument(textEditor.getEditorInput());
-                        
-                        if (selectionProvider != null && document != null) 
-                        {
-                            var selection = (org.eclipse.jface.text.ITextSelection) selectionProvider.getSelection();
-                            try 
-                            {
-                                // Replace selection or insert at cursor position
-                                if (selection.getLength() > 0) 
-                                {
-                                    // Replace selected text
-                                    document.replace(selection.getOffset(), selection.getLength(), codeBlock);
-                                }
-                                else 
-                                {
-                                    // Insert at cursor position
-                                    document.replace(selection.getOffset(), 0, codeBlock);
-                                }
-                            } 
-                            catch (org.eclipse.jface.text.BadLocationException e) 
-                            {
-                                logger.error("Error inserting code at location", e);
-                            }
-                        } 
-                        else 
-                        {
-                            logger.error("Selection provider or document is null");
-                        }
-                    });
-            } 
-            catch (Exception e) 
-            {
-                logger.error("Error inserting code", e);
-            }
-        });
-    }
-
-    public void onDiffCode(String codeBlock) {
-        uiSync.asyncExec(() -> {
-            try {
-                Optional.ofNullable(PlatformUI.getWorkbench())
-                    .map(workbench -> workbench.getActiveWorkbenchWindow())
-                    .map(window -> window.getActivePage())
-                    .map(page -> page.getActiveEditor())
-                    .flatMap(editor -> Optional.ofNullable(editor.getAdapter(org.eclipse.ui.texteditor.ITextEditor.class)))
-                    .ifPresent(textEditor -> {
-                        // Get the file information
-                        if (textEditor.getEditorInput() instanceof org.eclipse.ui.part.FileEditorInput) {
-                            org.eclipse.ui.part.FileEditorInput fileInput = 
-                                (org.eclipse.ui.part.FileEditorInput) textEditor.getEditorInput();
-                            
-                            // Get project name and file path
-                            String projectName = fileInput.getFile().getProject().getName();
-                            String filePath = fileInput.getFile().getProjectRelativePath().toString();
-                            
-                            // Generate diff using the CodeEditingService
-                            String diff = codeEditingService.generateCodeDiff(
-                                projectName, 
-                                filePath, 
-                                codeBlock, 
-                                3 // Default context lines
-                            );
-                            
-                            if (diff != null && !diff.isBlank() ) 
-                            {
-                                // Show the apply patch wizard with the generated diff and preselected project
-                                applyPatchWizzardHelper.showApplyPatchWizardDialog(diff, projectName);
-                            } else {
-                                logger.info("No differences found between current code and provided code block");
-                            }
-                        } else {
-                            logger.error("Cannot get file information from editor");
-                        }
-                    });
-            } catch (Exception e) {
-                logger.error("Error generating diff for code", e);
-            }
-        });
-    }
-
-
-
-    public void onNewFile(String codeBlock, String lang) 
+    public void onInsertCode( String codeBlock )
     {
-        uiSync.asyncExec(() -> {
-            try 
+        uiSync.asyncExec( () -> {
+            try
+            {
+                Optional.ofNullable( PlatformUI.getWorkbench() )
+                        .map( workbench -> workbench.getActiveWorkbenchWindow() )
+                        .map( window -> window.getActivePage() )
+                        .map( page -> page.getActiveEditor() )
+                        .flatMap( editor -> Optional.ofNullable( editor.getAdapter( org.eclipse.ui.texteditor.ITextEditor.class ) ) )
+                        .ifPresent( textEditor -> {
+                            var selectionProvider = textEditor.getSelectionProvider();
+                            var document = textEditor.getDocumentProvider()
+                                                     .getDocument( textEditor.getEditorInput() );
+                            if ( selectionProvider != null && document != null )
+                            {
+                                var selection = (org.eclipse.jface.text.ITextSelection) selectionProvider.getSelection();
+                                try
+                                {
+                                    if ( selection.getLength() > 0 )
+                                    {
+                                        document.replace( selection.getOffset(), selection.getLength(), codeBlock );
+                                    }
+                                    else
+                                    {
+                                        document.replace( selection.getOffset(), 0, codeBlock );
+                                    }
+                                }
+                                catch ( org.eclipse.jface.text.BadLocationException e )
+                                {
+                                    logger.error( "Error inserting code at location", e );
+                                }
+                            }
+                            else
+                            {
+                                logger.error( "Selection provider or document is null" );
+                            }
+                        } );
+            }
+            catch ( Exception e )
+            {
+                logger.error( "Error inserting code", e );
+            }
+        } );
+    }
+
+    public void onDiffCode( String codeBlock )
+    {
+        uiSync.asyncExec( () -> {
+            try
+            {
+                Optional.ofNullable( PlatformUI.getWorkbench() )
+                        .map( workbench -> workbench.getActiveWorkbenchWindow() )
+                        .map( window -> window.getActivePage() )
+                        .map( page -> page.getActiveEditor() )
+                        .flatMap( editor -> Optional.ofNullable( editor.getAdapter( org.eclipse.ui.texteditor.ITextEditor.class ) ) )
+                        .ifPresent( textEditor -> {
+                            if ( textEditor.getEditorInput() instanceof org.eclipse.ui.part.FileEditorInput )
+                            {
+                                org.eclipse.ui.part.FileEditorInput fileInput =
+                                        (org.eclipse.ui.part.FileEditorInput) textEditor.getEditorInput();
+                                String projectName = fileInput.getFile().getProject().getName();
+                                String filePath    = fileInput.getFile().getProjectRelativePath().toString();
+                                String diff        = codeEditingService.generateCodeDiff( projectName, filePath, codeBlock, 3 );
+                                if ( diff != null && !diff.isBlank() )
+                                {
+                                    applyPatchWizzardHelper.showApplyPatchWizardDialog( diff, projectName );
+                                }
+                                else
+                                {
+                                    logger.info( "No differences found between current code and provided code block" );
+                                }
+                            }
+                            else
+                            {
+                                logger.error( "Cannot get file information from editor" );
+                            }
+                        } );
+            }
+            catch ( Exception e )
+            {
+                logger.error( "Error generating diff for code", e );
+            }
+        } );
+    }
+
+    public void onNewFile( String codeBlock, String lang )
+    {
+        uiSync.asyncExec( () -> {
+            try
             {
                 IProject project = Optional.ofNullable( PlatformUI.getWorkbench() )
-                        .map(IWorkbench::getActiveWorkbenchWindow)
+                        .map( IWorkbench::getActiveWorkbenchWindow )
                         .map( IWorkbenchWindow::getActivePage )
                         .map( IWorkbenchPage::getActiveEditor )
-                        .map(editor -> editor.getEditorInput())
-                        .filter(input -> input instanceof org.eclipse.ui.part.FileEditorInput)
-                        .map(input -> ((org.eclipse.ui.part.FileEditorInput) input).getFile().getProject())
-                        .orElse(null);
+                        .map( editor -> editor.getEditorInput() )
+                        .filter( input -> input instanceof org.eclipse.ui.part.FileEditorInput )
+                        .map( input -> ((org.eclipse.ui.part.FileEditorInput) input).getFile().getProject() )
+                        .orElse( null );
 
-                if (project != null) 
+                if ( project != null )
                 {
-                    // Create suggested file name and path based on language
-                	String suggestedFileName = ResourceUtilities.getSuggestedFileName(lang, codeBlock);
-                    IPath suggestedPath      = ResourceUtilities.getSuggestedPath(project, lang, codeBlock);
-                    WizardNewFileCreationPage newFilePage = new WizardNewFileCreationPage("NewFilePage", new StructuredSelection(project));
-                    newFilePage.setTitle("New File");
-                    newFilePage.setDescription(String.format("Create a new %s file in the project", ResourceUtilities.getFileExtensionForLang( lang )) );
-                    
-                    // Set suggested file name and path
-                    if (suggestedPath != null) 
+                    String suggestedFileName = ResourceUtilities.getSuggestedFileName( lang, codeBlock );
+                    IPath  suggestedPath     = ResourceUtilities.getSuggestedPath( project, lang, codeBlock );
+                    WizardNewFileCreationPage newFilePage = new WizardNewFileCreationPage( "NewFilePage", new StructuredSelection( project ) );
+                    newFilePage.setTitle( "New File" );
+                    newFilePage.setDescription( String.format( "Create a new %s file in the project", ResourceUtilities.getFileExtensionForLang( lang ) ) );
+                    if ( suggestedPath != null )
                     {
-                        newFilePage.setContainerFullPath(suggestedPath);
+                        newFilePage.setContainerFullPath( suggestedPath );
                     }
-                    if (suggestedFileName != null && !suggestedFileName.isBlank()) 
+                    if ( suggestedFileName != null && !suggestedFileName.isBlank() )
                     {
-                        newFilePage.setFileName(suggestedFileName);
+                        newFilePage.setFileName( suggestedFileName );
                     }
-                    
-                    
-                    Wizard wizard = new Wizard() {
+
+                    Wizard wizard = new Wizard()
+                    {
                         @Override
-                        public void addPages() 
+                        public void addPages()
                         {
-                            addPage(newFilePage);
+                            addPage( newFilePage );
                         }
 
                         @Override
-                        public boolean performFinish() {
+                        public boolean performFinish()
+                        {
                             IFile newFile = newFilePage.createNewFile();
-                            if (newFile != null) 
+                            if ( newFile != null )
                             {
-                                try (InputStream stream = new ByteArrayInputStream(codeBlock.getBytes(StandardCharsets.UTF_8))) 
+                                try ( InputStream stream = new ByteArrayInputStream( codeBlock.getBytes( StandardCharsets.UTF_8 ) ) )
                                 {
-                                    newFile.setContents(stream, true, true, null);
-                                    logger.info("New file created at: " + newFile.getFullPath().toString());
+                                    newFile.setContents( stream, true, true, null );
+                                    logger.info( "New file created at: " + newFile.getFullPath().toString() );
                                     return true;
-                                } 
-                                catch (CoreException | IOException e) 
+                                }
+                                catch ( CoreException | IOException e )
                                 {
-                                    logger.error("Error creating new file", e);
+                                    logger.error( "Error creating new file", e );
                                 }
                             }
                             return false;
                         }
                     };
 
-                    WizardDialog dialog = new WizardDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), wizard);
+                    WizardDialog dialog = new WizardDialog( PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), wizard );
                     dialog.open();
-                } 
-                else 
-                {
-                    logger.error("No active project found");
                 }
-            } 
-            catch (Exception e) 
-            {
-                logger.error("Error opening new file wizard", e);
+                else
+                {
+                    logger.error( "No active project found" );
+                }
             }
-        });
+            catch ( Exception e )
+            {
+                logger.error( "Error opening new file wizard", e );
+            }
+        } );
     }
-    
+
     /**
      * Handles model selection from the dropdown menu.
-     * 
-     * This method is called when a user selects a different AI model from the
-     * dropdown menu in the UI. It updates the preferences to store the selected
-     * model and would typically update any service configurations to use the new model.
-     * 
-     * @param modelId The ID of the selected model
+     *
+     * @param modelId the ID of the selected model
      */
-    public void onChatModelSelected(String modelId) 
+    public void onChatModelSelected( String modelId )
     {
-        logger.info("Model selected: " + modelId);
-        
+        logger.info( "Model selected: " + modelId );
         modelReposotiry.setChatModelInUse( modelId );
         initializeAvailableModels();
     }
-    
+
     /**
      * Regenerates the last AI response using the currently selected model.
-     * 
-     * This method is called when the user clicks the replay button. It removes
-     * the last assistant message from the conversation (if it exists) and
-     * sends the conversation again to generate a new response.
      */
-    public void onReplayLastMessage() {
-        logger.info("Replaying last message with current model");
-        
-        // Check if there's a conversation with at least one message
-        if (conversation.messages().isEmpty()) 
+    public void onReplayLastMessage()
+    {
+        logger.info( "Replaying last message with current model" );
+        if ( conversation.messages().isEmpty() )
         {
             return;
         }
-        // If the last message is from the assistant, remove it
-        // (We want to regenerate the assistant's response)
         List<ChatMessage> messages = conversation.messages();
-        if (!messages.isEmpty() && "assistant".equals(messages.get(messages.size() - 1).getRole())) {
-            ChatMessage lastMessage = messages.get(messages.size() - 1);
+        if ( !messages.isEmpty() && "assistant".equals( messages.get( messages.size() - 1 ).getRole() ) )
+        {
+            ChatMessage lastMessage = messages.get( messages.size() - 1 );
             conversation.removeLastMessage();
-            
-            // Remove the message from the UI
-            applyToView(view -> {
-                view.removeMessage(lastMessage.getId());
-            });
+            applyToView( view -> {
+                view.removeMessage( lastMessage.getId() );
+            } );
         }
-        // Send the conversation for processing to generate a new response
-    	sendConversationJobProvider.get().schedule();
+        sendConversationJobProvider.get().schedule();
     }
 
-	public void onViewVisible() 
-	{
-		initializeAvailableModels();
-		updateAutocomplete();
-	}
-	
-	public void onRemoveMessage(String messageId )
-	{
-	    this.conversation.removeMessageById( messageId );
-	    applyToView( view -> {
-	        view.removeMessage( messageId );
-	    } );
-	}
-	
-	public void onRemoveAttachment( int index )
-	{
-	    if ( index >= 0 && index < attachments.size() )
-	    {
-	        attachments.remove( index );
-	        applyToView( view -> {
-	            view.setAttachments( attachments );
-	        } );
-	    }
-	}
-	
+    public void onViewVisible()
+    {
+        initializeAvailableModels();
+        updateAutocomplete();
+    }
+
+    public void onRemoveMessage( String messageId )
+    {
+        this.conversation.removeMessageById( messageId );
+        applyToView( view -> {
+            view.removeMessage( messageId );
+        } );
+    }
+
+    public void onRemoveAttachment( int index )
+    {
+        if ( index >= 0 && index < attachments.size() )
+        {
+            attachments.remove( index );
+            applyToView( view -> {
+                view.setAttachments( attachments );
+            } );
+        }
+    }
+
     public void updateAutocomplete()
     {
         Map<String, String> mappings = promptRepository.getAllPrompts()
                                                        .stream()
                                                        .collect( Collectors.toMap( Prompts::getCommandName, Prompts::getDescription ) );
-        applyToView( view -> view.setAutocompleteModel( mappings  ) );
+        applyToView( view -> view.setAutocompleteModel( mappings ) );
+    }
+
+    // -------------------------------------------------------------------------
+    // Chat history
+    // -------------------------------------------------------------------------
+
+    /**
+     * Opens the Chat History dialog.  If the user selects a session and presses
+     * Load, the current conversation is replaced by the stored one.
+     */
+    public void onShowHistory()
+    {
+        uiSync.asyncExec( () -> {
+            Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+
+            List<ChatHistorySession> sessions = new ArrayList<>( historyRepository.listSessions() );
+            if ( sessions.isEmpty() )
+            {
+                MessageDialog.openInformation(
+                        shell,
+                        "Chat History",
+                        "No saved sessions found yet.\n\nSessions are saved automatically after each assistant response." );
+                return;
+            }
+
+            ChatHistoryDialog dialog = new ChatHistoryDialog( shell, sessions );
+            int rc = dialog.open();
+
+            // Apply deletions the user made inside the dialog
+            List<String> remainingIds = dialog.getRemainingSessionIds()
+                                              .stream()
+                                              .map( ChatHistorySession::id )
+                                              .collect( Collectors.toList() );
+            historyRepository.listSessions().stream()
+                             .filter( s -> !remainingIds.contains( s.id() ) )
+                             .forEach( s -> historyRepository.deleteSession( s.id() ) );
+
+            // Load the selected session when the user pressed Load
+            if ( rc == org.eclipse.jface.dialogs.Dialog.OK )
+            {
+                ChatHistorySession loaded = dialog.getLoadedSession();
+                if ( loaded != null )
+                {
+                    loadHistorySession( loaded );
+                }
+            }
+        } );
+    }
+
+    /**
+     * Replaces the current conversation with the messages from the given
+     * persisted session and re-renders the chat view.
+     *
+     * @param session the session to restore
+     */
+    private void loadHistorySession( ChatHistorySession session )
+    {
+        onStop();
+        conversation.clear();
+        attachments.clear();
+        resourceCache.clear();
+
+        List<ChatMessage> restored = new ArrayList<>();
+        if ( session.messages() != null )
+        {
+            for ( PersistedMessage pm : session.messages() )
+            {
+                ChatMessage msg = new ChatMessage( pm.id(), pm.name(), pm.role() );
+                msg.setContent( pm.content() != null ? pm.content() : "" );
+
+                // Restore file attachments (images cannot be persisted)
+                if ( pm.attachments() != null )
+                {
+                    List<Attachment> atts = new ArrayList<>();
+                    for ( var pa : pm.attachments() )
+                    {
+                        if ( "file".equals( pa.type() ) )
+                        {
+                            atts.add( new Attachment.FileContentAttachment(
+                                    pa.filePath(),
+                                    pa.lineNumberStart(),
+                                    pa.lineNumberEnd(),
+                                    pa.selectedContent() ) );
+                        }
+                    }
+                    msg.setAttachments( atts );
+                }
+                restored.add( msg );
+            }
+        }
+        restored.forEach( conversation::add );
+
+        // Mark this session as current so subsequent auto-saves update the same file
+        historyRepository.setCurrentSession( session.id() );
+
+        // Re-render the chat view with the restored messages
+        applyToView( view -> {
+            view.clearChatView();
+            view.clearAttachments();
+            view.renderConversation( restored );
+        } );
     }
 }


### PR DESCRIPTION
Persist and restore past chat sessions, and we can restore them if necessary.

**Note**
1.Serializes each conversation to a JSON file under the plugin's state location (.metadata/.plugins/<bundle-id>/history/)
2.Image attachments are intentionally not persisted (binary data too large); file-content attachments are fully restored
3.Loading a session **replaces** the current conversation
4.No limit on the number of saved sessions