### PR TITLE
Resolve the active text editor through the adapter chain

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/completion/AICompletionHandler.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/completion/AICompletionHandler.java
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -74,11 +75,12 @@ public class AICompletionHandler extends AbstractHandler {
         }
         
         IEditorPart editor = page.getActiveEditor();
-        if (!(editor instanceof ITextEditor)) {
+        ITextEditor textEditor = Adapters.adapt(editor, ITextEditor.class);
+        if (textEditor == null) {
+            logger.info("AI completion is not available for the active editor: "
+                    + (editor == null ? "none" : editor.getClass().getName()));
             return null;
         }
-        
-        ITextEditor textEditor = (ITextEditor) editor;
         
         
         try {

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/EditorService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/EditorService.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.e4.core.di.annotations.Creatable;
@@ -151,8 +152,8 @@ public class EditorService
     public ResourceReadResult readEditorSelection()
     {
         return uiSync.syncCall( () -> {
-            Optional<IEditorPart> editor = getActiveEditor();
-            if ( editor.isEmpty() || !( editor.get() instanceof ITextEditor textEditor ) )
+            Optional<ITextEditor> activeTextEditor = getActiveTextEditor();
+            if ( activeTextEditor.isEmpty() )
             {
                 return ResourceReadResult.failed( null, null, Diagnostic.fatal(
                         DiagnosticCode.RESOURCE_NOT_FOUND,
@@ -168,6 +169,7 @@ public class EditorService
                                 + " from AI processing by .aiignore." ) );
             }
 
+            ITextEditor textEditor = activeTextEditor.get();
             IFile file = opened.get();
             IDocument document = textEditor.getDocumentProvider().getDocument( textEditor.getEditorInput() );
             ISelection selection = textEditor.getSelectionProvider().getSelection();
@@ -367,8 +369,7 @@ public class EditorService
     private Optional<ITextEditor> getActiveTextEditor()
     {
         return getActiveEditor()
-                .filter(editor -> editor instanceof ITextEditor)
-                .map(editor -> (ITextEditor) editor);
+                .flatMap( editor -> Adapters.of( editor, ITextEditor.class ) );
     }
 
 }


### PR DESCRIPTION
Fixes #156.

### Problem

`AI Code Completion` is a no-op in editors whose text editor is a nested page of a `MultiPageEditorPart` — in practice, all ABAP editors of SAP ADT. Nothing is shown, nothing is logged, no request is sent.

### Root cause

`AICompletionHandler.execute()` required the active editor part itself to be an `ITextEditor`:

```java
IEditorPart editor = page.getActiveEditor();
if (!(editor instanceof ITextEditor)) {
    return null;
}
```

In a multi-page editor the text editor is a nested page, so `page.getActiveEditor()` returns the wrapper and the check fails. For ADT:

```
AbapSourceMultiPageEditor  extends org.eclipse.ui.part.MultiPageEditorPart
AbapSourceSinglePageEditor extends AbapSourceMultiPageEditor   // despite the name
FunctionModuleEditor       extends AbapSourceSinglePageEditor
AbapSourcePage             extends org.eclipse.ui.texteditor.AbstractDecoratedTextEditor
```

### Fix

Resolve the text editor through the adapter chain, which `MultiPageEditorPart#getAdapter` delegates to the active page:

```java
ITextEditor textEditor = Adapters.adapt(editor, ITextEditor.class);
```

`Adapters.adapt` returns the object itself when it already is an `ITextEditor`, so plain editors behave exactly as before, and a multi-page editor resolves only while the active page is a text editor — on a form or design tab nothing happens, as today. This is the same approach already used in `CodeEditingService` (line 636) and `ChatViewPresenter`.

The rest of the completion path needed no change: `getGhostTextManager` already resolves `ISourceViewer` by adapter with a reflection fallback, which works for `AbstractTextEditor` subclasses.

### Why `EditorService` is part of the same fix

`${codeBeforeCursor}` and `${codeAfterCursor}` in `completion-prompt.md` are resolved by `PromptContextValueProvider` (lines 80-81) through `EditorService.getActiveTextEditor()`, which filtered by `instanceof` in the same way. Fixing only the handler would send the completion request with an empty code context. `getActiveTextEditor()` now goes through `Adapters.of(...)`, and `readEditorSelection()` reuses it instead of its own check — which also fixes the editor-selection MCP tools reporting "No text editor is active" for these editors.

### What this does not change — and a question for you

The binding stays `Alt+/` in `org.eclipse.jdt.ui.javaEditorScope`, so ABAP users still have to bind the command themselves in the **Editing Text** context. I deliberately left that alone: moving the binding to `org.eclipse.ui.textEditorScope` would collide with the platform's own `org.eclipse.ui.edit.text.hippieCompletion`, which takes `M3+/` in exactly that context. Today AssistAI wins in the Java editor only because a child-context binding outranks the parent's; in the same context the two would conflict and the key would stop doing either thing for existing users. The only unbind of `M3+/` in the platform is guarded by `platform="carbon"`, which current macOS builds no longer match since they run on cocoa, so the conflict would apply there too.

So the default binding seems to be a UX call for you rather than something to slip into this PR. If you would like a wider default, I am happy to follow up with whatever you prefer — a different sequence in `textEditorScope`, or additional context ids.

### A note on diagnosability

Every early exit in the handler returns silently, which is what made this take a while to pin down — an empty log looks identical to a missing key binding. I added one `logger.info` on the path where no text editor can be resolved. Happy to drop it if you would rather keep the handler quiet.

### Verification

- `mvn clean verify -DskipTests` (Maven 3.9.16, Tycho 5.0.2, JavaSE-21 toolchain): BUILD SUCCESS, all six modules.
- The class hierarchy, the `getAdapter` delegation and the binding contexts above were read from the shipped ADT 3.60.3 and platform bytecode and `plugin.xml`, not assumed.
- Runtime check in a live ADT editor is still pending on my side; I will follow up with a comment once I have run it.
