### PR TITLE
Keep the file's line delimiter when formatting

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeEditingService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeEditingService.java
@@ -64,6 +64,7 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.FindReplaceDocumentAdapter;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.TextUtilities;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
 import org.eclipse.swt.SWT;
@@ -512,7 +513,7 @@ public class CodeEditingService
             CodeFormatter formatter = ToolFactory.createCodeFormatter( options );
 
             // Format the code
-            TextEdit textEdit = formatter.format( CodeFormatter.K_COMPILATION_UNIT | CodeFormatter.F_INCLUDE_COMMENTS, code, 0, code.length(), 0, null );
+            TextEdit textEdit = formatter.format( CodeFormatter.K_COMPILATION_UNIT | CodeFormatter.F_INCLUDE_COMMENTS, code, 0, code.length(), 0, lineDelimiterFor( code, projectName ) );
 
             if ( textEdit == null )
             {
@@ -533,6 +534,13 @@ public class CodeEditingService
             logger.error( "Error during code formatting: " + e.getMessage(), e );
             throw new RuntimeException( "Error formatting code: " + e.getMessage(), e );
         }
+    }
+
+    /** The delimiter the code already uses, or the configured one for code without a line break. */
+    private String lineDelimiterFor( String code, String projectName )
+    {
+        String used = TextUtilities.determineLineDelimiter( code, null );
+        return used != null ? used : getLineDelimiterPreference( projectName ).delimiter();
     }
 
     /**
@@ -2819,13 +2827,13 @@ public class CodeEditingService
             // Format as statements (K_STATEMENTS works better for code
             // fragments)
             TextEdit textEdit = formatter.format( CodeFormatter.K_STATEMENTS | CodeFormatter.F_INCLUDE_COMMENTS, combinedCode, completionOffset,
-                    completionLength, getIndentationLevel( codeBefore ), null );
+                    completionLength, getIndentationLevel( codeBefore ), lineDelimiterFor( combinedCode, null ) );
 
             if ( textEdit == null )
             {
                 // Try formatting as unknown kind
                 textEdit = formatter.format( CodeFormatter.K_UNKNOWN, combinedCode, completionOffset, completionLength, getIndentationLevel( codeBefore ),
-                        null );
+                        lineDelimiterFor( combinedCode, null ) );
             }
 
             if ( textEdit == null )

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeEditingServicePDETest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeEditingServicePDETest.java
@@ -1,6 +1,7 @@
 package com.github.gradusnikov.eclipse.assistai.mcp.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -797,6 +798,31 @@ public class ApplicationNew {
         assertTrue( result.diagnostics().isEmpty(), () -> result.diagnostics().toString() );
         assertTrue( !ResourceUtilities.readFileContent( project.getFile( "src/pkg/Unused.java" ) )
                 .contains( "import java.util.List" ) );
+    }
+
+    @Test
+    public void testFormatCode_keepsTheLineDelimiterOfTheInput() {
+        String lfSource = "package x;\npublic class A {\nint a;\nvoid f(){a=1;}\n}\n";
+
+        String lfFormatted = service.formatCode(lfSource, TEST_PROJECT_NAME);
+        assertTrue(lfFormatted.contains("a = 1;"), lfFormatted);
+        assertFalse(lfFormatted.contains("\r"), lfFormatted);
+
+        String crlfFormatted = service.formatCode(lfSource.replace("\n", "\r\n"), TEST_PROJECT_NAME);
+        assertTrue(crlfFormatted.contains("a = 1;"), crlfFormatted);
+        assertFalse(crlfFormatted.replace("\r\n", "").contains("\n"), crlfFormatted);
+    }
+
+    @Test
+    public void testFormatFile_javaFileKeepsItsLineDelimiter() throws CoreException, IOException {
+        IFile testFile = createFile("src/A.java", "package x;\npublic class A {\nint a;\nvoid f(){a=1;}\n}\n");
+
+        EditResult result = service.formatFile(TEST_PROJECT_NAME, "src/A.java");
+
+        assertEquals(EditResult.EditStatus.APPLIED, result.status());
+        String formatted = ResourceUtilities.readFileContent(testFile);
+        assertTrue(formatted.contains("a = 1;"), formatted);
+        assertFalse(formatted.contains("\r"), formatted);
     }
 
     private IFile createFile(String path, String content) throws CoreException {


### PR DESCRIPTION
formatCode, formatFile and completion formatting passed null as the line separator to CodeFormatter.format, which JDT reads as the JVM default. 

On Windows that rewrote every line as CRLF regardless of the Eclipse settings, turning a small reformat into a whole-file diff. Combined with Claude Code always producing LF strings for other endpoints (such as by-string replacement) this lead to an awful amount of churn.

Use the delimiter the code already has, falling back to the project's Eclipse preference.