### PR TITLE
allow scoping of compilation errors

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/docs/mcp-api.md
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/docs/mcp-api.md
@@ -676,12 +676,13 @@ Returns the outline of a Java class: its declaration plus fields, method signatu
 
 ### `getCompilationErrors`
 
-Retrieves compilation errors and problems from the current workspace or a specific project. Reports errorCount/warningCount for everything that matched, before any truncation, so 'are there errors?' is answerable even from a shortened listing. Each problem carries its markerId and quick-fix indices for executeQuickFix.
+Retrieves compilation errors and problems from the current workspace, a specific project, or one folder or file within it. Reports errorCount/warningCount for everything that matched, before any truncation, so 'are there errors?' is answerable even from a shortened listing. Each problem carries its markerId and quick-fix indices for executeQuickFix.
 
 | Parameter | | Description |
 |---|---|---|
 | `projectName` |  | The name of the specific project to check (optional, leave empty for all projects) |
-| `severity` |  | Filter by severity level: 'ERROR', 'WARNING', or 'ALL' (default) |
+| `resourcePath` |  | Project-relative path of a folder or file to restrict the report to, e.g. 'src/com/example' or 'src/com/example/Foo.java' (optional, requires projectName) |
+| `severity` |  | Filter by severity level: 'ERROR', 'WARNING', 'INFO' or 'ALL' (default) |
 | `maxResults` |  | Maximum number of problems to return (default: 50) |
 
 **Returns** [`CompilationProblemsResponse`](#compilationproblemsresponse)

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/EclipseIntegrationsMcpServer.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/servers/EclipseIntegrationsMcpServer.java
@@ -233,18 +233,20 @@ public class EclipseIntegrationsMcpServer
                 Optional.ofNullable( maxDepth ).map( Integer::parseInt ).orElse( 0 ) );
     }
 
-    @Tool( name = "getCompilationErrors", description = "Retrieves compilation errors and problems from the current workspace or a specific project. "
+    @Tool( name = "getCompilationErrors", description = "Retrieves compilation errors and problems from the current workspace, a specific project, or one folder or file within it. "
             + "Reports errorCount/warningCount for everything that matched, before any truncation, so 'are there errors?' is answerable "
             + "even from a shortened listing. Each problem carries its markerId and quick-fix indices for executeQuickFix.",
             type = "object", outputType = CompilationProblemsResponse.class )
     public CompilationProblemsResponse getCompilationErrors(
             @ToolParam( name = "projectName", description = "The name of the specific project to check (optional, leave empty for all projects)", required = false )
             String projectName,
-            @ToolParam( name = "severity", description = "Filter by severity level: 'ERROR', 'WARNING', or 'ALL' (default)", required = false )
+            @ToolParam( name = "resourcePath", description = "Project-relative path of a folder or file to restrict the report to, e.g. 'src/com/example' or 'src/com/example/Foo.java' (optional, requires projectName)", required = false )
+            String resourcePath,
+            @ToolParam( name = "severity", description = "Filter by severity level: 'ERROR', 'WARNING', 'INFO' or 'ALL' (default)", required = false )
             String severity, @ToolParam( name = "maxResults", description = "Maximum number of problems to return (default: 50)", required = false )
             String maxResults )
     {
-        return codeAnalysisService.getCompilationErrors( projectName, severity,
+        return codeAnalysisService.getCompilationErrors( projectName, resourcePath, severity,
                 Optional.ofNullable( maxResults ).map( Integer::parseInt ).orElse( 0 ) );
     }
 

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeAnalysisService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeAnalysisService.java
@@ -173,17 +173,26 @@ public class CodeAnalysisService
         return null;
     }
     
+    /** Collects compilation problems from the workspace or a single project. */
+    public CompilationProblemsResponse getCompilationErrors( String projectName, String severity, Integer maxResults )
+    {
+        return getCompilationErrors( projectName, null, severity, maxResults );
+    }
+
     /**
-     * Collects compilation problems from the workspace or a single project.
+     * Collects compilation problems from the workspace, a project, or one folder or file
+     * within a project.
      * <p>
      * Collection only - the rendering is the record's JSON serialization, so how
      * problems are described can change without changing which problems are reported.
      *
-     * @param severity {@code ERROR}, {@code WARNING} or {@code ALL} (default)
+     * @param resourcePath project-relative path of a folder or file to restrict the report
+     *            to; requires {@code projectName}
+     * @param severity {@code ERROR}, {@code WARNING}, {@code INFO} or {@code ALL} (default)
      * @param maxResults how many problems to list; the counts are of everything that
      *            matched, so a truncated reply still answers "are there errors?"
      */
-    public CompilationProblemsResponse getCompilationErrors( String projectName, String severity, Integer maxResults )
+    public CompilationProblemsResponse getCompilationErrors( String projectName, String resourcePath, String severity, Integer maxResults )
     {
         String requestedSeverity = ( severity == null || severity.isBlank() ) ? "ALL" : severity.toUpperCase();
         int limit = ( maxResults == null || maxResults < 1 ) ? 50 : maxResults;
@@ -192,6 +201,7 @@ public class CodeAnalysisService
         {
             case "ERROR" -> IMarker.SEVERITY_ERROR;
             case "WARNING" -> IMarker.SEVERITY_WARNING;
+            case "INFO" -> IMarker.SEVERITY_INFO;
             default -> -1;
         };
 
@@ -210,8 +220,25 @@ public class CodeAnalysisService
                 {
                     throw new RuntimeException( "Project '" + projectName + "' is closed." );
                 }
-                scope = "Project: " + projectName;
-                markers = project.findMarkers( IMarker.PROBLEM, true, IResource.DEPTH_INFINITE );
+                if ( resourcePath != null && !resourcePath.isBlank() )
+                {
+                    IResource resource = project.findMember( resourcePath );
+                    if ( resource == null )
+                    {
+                        throw new RuntimeException( "Resource '" + resourcePath + "' not found in project '" + projectName + "'." );
+                    }
+                    scope = ( resource instanceof IFile ? "File: " : "Folder: " ) + projectName + "/" + resource.getProjectRelativePath();
+                    markers = resource.findMarkers( IMarker.PROBLEM, true, IResource.DEPTH_INFINITE );
+                }
+                else
+                {
+                    scope = "Project: " + projectName;
+                    markers = project.findMarkers( IMarker.PROBLEM, true, IResource.DEPTH_INFINITE );
+                }
+            }
+            else if ( resourcePath != null && !resourcePath.isBlank() )
+            {
+                throw new RuntimeException( "resourcePath requires projectName." );
             }
             else
             {

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeAnalysisServicePDETest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeAnalysisServicePDETest.java
@@ -2,6 +2,7 @@
 package com.github.gradusnikov.eclipse.assistai.mcp.services;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -600,6 +601,49 @@ public class CodeAnalysisServicePDETest {
         createFile("src/com/example/Callee.java", calleeSource);
     }
     
+    @Test
+    public void testGetCompilationErrors_scopedToFolderOrFile() throws CoreException, InterruptedException {
+        createClassWithErrors();
+        createClassWithWarnings();
+        IFolder otherPackage = project.getFolder(new Path("src/com/other"));
+        if (!otherPackage.exists()) {
+            otherPackage.create(true, true, monitor);
+        }
+        createFile("src/com/other/AlsoBroken.java",
+                "package com.other;\n\npublic class AlsoBroken {\n    int x = undefinedVariable;\n}\n");
+
+        project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+        project.build(IncrementalProjectBuilder.FULL_BUILD, monitor);
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, monitor);
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, monitor);
+        Thread.sleep(500);
+
+        IMarker[] markers = project.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
+        org.junit.jupiter.api.Assumptions.assumeTrue(markers.length > 0,
+                "No error markers generated - Java builder not active in this environment");
+
+        CompilationProblemsResponse oneFile = service.getCompilationErrors(
+                testProjectName, "src/com/example/ErrorClass.java", "ALL", 50);
+        assertTrue(oneFile.hasErrors(), "the broken class must report its own error");
+        assertEquals(1, oneFile.files().size(), "a file scope lists that file only");
+        assertEquals("src/com/example/ErrorClass.java", oneFile.files().get(0).filePath());
+
+        CompilationProblemsResponse oneFolder = service.getCompilationErrors(
+                testProjectName, "src/com/example", "ALL", 50);
+        assertTrue(oneFolder.totalProblems() >= oneFile.totalProblems());
+        assertTrue(oneFolder.files().stream().allMatch(f -> f.filePath().startsWith("src/com/example/")),
+                "a folder scope must not list files outside the folder");
+
+        CompilationProblemsResponse wholeProject = service.getCompilationErrors(testProjectName, null, "ALL", 50);
+        assertTrue(wholeProject.totalProblems() > oneFolder.totalProblems(),
+                "the error in com.other lies outside the folder scope");
+
+        assertThrows(RuntimeException.class,
+                () -> service.getCompilationErrors(testProjectName, "src/com/missing", "ALL", 50));
+        assertThrows(RuntimeException.class,
+                () -> service.getCompilationErrors(null, "src/com/example", "ALL", 50));
+    }
+
     private void createClassWithErrors() throws CoreException {
         // Create a class with compilation errors (undefined variable)
         String errorSource = 


### PR DESCRIPTION
getCompilationErrors can only return errors/warnings in the entire workspace or in a project. This is too large a net, Claude Code won't even load it as a response most of the time and will dump it to file instead.

And then that file is a single-line json so can't even be grepped. Basically not usable without additional postprocessing.

This PR: introduce an additional parameter `resourcePath` which allows scoping the errors down to directory or file level.

Also allow requesting INFO severity. Mostly for completeness but for me those are a sonarqube warnings. Previously only available by using `ALL`.