### PR TITLE
correctly write organised imports to disk even if the file is open in editor

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeEditingService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeEditingService.java
@@ -1762,24 +1762,21 @@ public class CodeEditingService
                     true,  // allowSyntaxErrors
                     chooseImportQuery );
 
-            operation.run( monitor );
-            compilationUnit.getResource().refreshLocal( IResource.DEPTH_ZERO, monitor );
-
-            String newSource = compilationUnit.getSource();
+            // OrganizeImportsOperation.run() saves through ICompilationUnit.save(), which is a
+            // no-op for a working copy - and the editor opened above makes this unit one. Take
+            // the edit and write it through the same path as every other edit instead.
+            String newSource = organizedSource( operation, originalSource, monitor );
+            if ( !originalSource.equals( newSource ) )
+            {
+                TextEditRequest edit = minimalReplacement( new Document( originalSource ), originalSource, newSource );
+                return applyTextEdits( projectName, filePath, IResource.NULL_STAMP, List.of( edit ), false );
+            }
 
             EditSynchronization synchronization = synchronizeAfterEdit( file, 1, currentHistoryState( file ) );
             List<Diagnostic> diagnostics = new ArrayList<>();
 
-            // JDT's operation wrote the compilation unit itself, through the Java
-            // model, so there is no text edit to route through applyTextEdits. This
-            // describes what it did, in the fields a caller reads for any other edit.
-            TextEditRequest describedAs = minimalReplacement( new Document( originalSource ), originalSource, newSource );
-            List<AppliedEdit> applied = originalSource.equals( newSource )
-                    ? List.of()
-                    : List.of( new AppliedEdit( describedAs.range(),
-                            ContentRange.wholeDocument( new Document( newSource ) ),
-                            describedAs.replacement().length(),
-                            describedAs.expectedText().length() ) );
+            // Nothing to organize: report the untouched file in the fields a caller reads for any other edit.
+            List<AppliedEdit> applied = List.of();
 
             return new EditResult(
                     diagnostics.isEmpty() ? EditStatus.APPLIED : EditStatus.APPLIED_WITH_WARNINGS,
@@ -1799,6 +1796,20 @@ public class CodeEditingService
         {
             throw new RuntimeException( "Error during organize imports: " + ExceptionUtils.getRootCauseMessage( e ), e );
         }
+    }
+
+    /** The source with imports organized, or the original when the operation finds nothing to change. */
+    private static String organizedSource( OrganizeImportsOperation operation, String originalSource, IProgressMonitor monitor )
+            throws CoreException, BadLocationException
+    {
+        TextEdit edit = operation.createTextEdit( monitor );
+        if ( edit == null )
+        {
+            return originalSource;
+        }
+        IDocument document = new Document( originalSource );
+        edit.apply( document );
+        return document.get();
     }
 
     /**
@@ -1898,12 +1909,17 @@ public class CodeEditingService
 
                     OrganizeImportsOperation operation = new OrganizeImportsOperation( cu, null, true, true, true, chooseImportQuery );
 
-                    operation.run( monitor );
-                    cu.getResource().refreshLocal( IResource.DEPTH_ZERO, monitor );
+                    String newSource = organizedSource( operation, originalSource, monitor );
 
-                    if ( !originalSource.equals( cu.getSource() ) && cu.getResource() instanceof IFile changedFile )
+                    if ( !originalSource.equals( newSource ) && cu.getResource() instanceof IFile changedFile )
                     {
-                        resourceCache.resourceChanged( changedFile.getFullPath() );
+                        TextEditRequest edit = minimalReplacement( new Document( originalSource ), originalSource, newSource );
+                        EditResult written = applyTextEdits( projectName, changedFile.getProjectRelativePath().toString(),
+                                IResource.NULL_STAMP, List.of( edit ), false );
+                        if ( written.status() == EditStatus.REJECTED )
+                        {
+                            throw new IllegalStateException( written.diagnostics().get( 0 ).message() );
+                        }
                         changed.add( AffectedResource.of( changedFile, ChangeKind.MODIFIED ) );
                         if ( firstChangedFile == null )
                         {

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeEditingServicePDETest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeEditingServicePDETest.java
@@ -2,6 +2,7 @@ package com.github.gradusnikov.eclipse.assistai.mcp.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -27,6 +28,9 @@ import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.EclipseContextFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.di.UISynchronize;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.IDE;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -798,6 +802,39 @@ public class ApplicationNew {
         assertTrue( result.diagnostics().isEmpty(), () -> result.diagnostics().toString() );
         assertTrue( !ResourceUtilities.readFileContent( project.getFile( "src/pkg/Unused.java" ) )
                 .contains( "import java.util.List" ) );
+    }
+
+    @Test
+    public void testOrganizeImports_writesTheFileWhileItIsOpenInAnEditor() throws Exception
+    {
+        project.getFolder( "src/pkg" ).create( IResource.NONE, true, monitor );
+        IFile file = createFile( "src/pkg/Open.java", "package pkg;\n\nimport java.util.List;\n\npublic class Open {}\n" );
+
+        // An open editor makes JDT treat the unit as a working copy, whose save() is a no-op.
+        PlatformUI.getWorkbench().getDisplay().syncExec( () -> {
+            try
+            {
+                IDE.openEditor( PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), file );
+            }
+            catch ( PartInitException e )
+            {
+                throw new IllegalStateException( e );
+            }
+        } );
+        try
+        {
+            EditResult result = service.organizeImports( TEST_PROJECT_NAME, "src/pkg/Open.java" );
+
+            assertEquals( EditResult.EditStatus.APPLIED, result.status() );
+            assertFalse( ResourceUtilities.readFileContent( file ).contains( "import java.util.List" ),
+                    "the organized imports must reach the disk, not only the editor buffer" );
+            assertNotEquals( result.versionBefore().modificationStamp(), result.versionAfter().modificationStamp() );
+        }
+        finally
+        {
+            PlatformUI.getWorkbench().getDisplay().syncExec(
+                    () -> PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().closeAllEditors( false ) );
+        }
     }
 
     @Test


### PR DESCRIPTION
organizeImports does not save, even though it says status="APPLIED" and savedToDisk: true.

It's a trap from Eclipse's API. Here's the sequence of events:
* organizeImports opens the file in an editor first
* then runs JDT's OrganizeImportsOperation with save=true
* this internally reaches CompilationUnit.save, which checks isWorkingCopy(), and for a working copy it only calls reconcile(). This is documented, the open editor is considered to be the place where it got "saved"
* saving to disk never happens

This PR: Take the operation's text edit and write it through applyTextEdits like every other edit.