### PR TITLE
MCP: don't echo back a diff that just matches the input

### DIFF
--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeEditingService.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeEditingService.java
@@ -246,7 +246,7 @@ public class CodeEditingService
 
             TextEditRequest edit = minimalReplacement( new Document( current ), current, restored );
 
-            return applyTextEdits( projectName, filePath, IResource.NULL_STAMP, List.of( edit ), false );
+            return applyTextEdits( projectName, filePath, IResource.NULL_STAMP, List.of( edit ), false, true );
         }
         catch ( CoreException | IOException | BadLocationException e )
         {
@@ -571,7 +571,7 @@ public class CodeEditingService
             {
                 String formatted = formatCode( originalContent, projectName );
                 TextEditRequest edit = minimalReplacement( new Document( originalContent ), originalContent, formatted );
-                return applyTextEdits( projectName, filePath, IResource.NULL_STAMP, List.of( edit ), false );
+                return applyTextEdits( projectName, filePath, IResource.NULL_STAMP, List.of( edit ), false, true );
             }
 
             formatUsingRegisteredEditor( file );
@@ -781,7 +781,7 @@ public class CodeEditingService
                     ResourceVersion.UNKNOWN,
                     synchronization.version(),
                     List.of( new AppliedEdit( new ContentRange( 1, 1, 1, 1 ), newRange, created.length(), 0 ) ),
-                    UnifiedDiffs.diff( "", normalizedPath, created, normalizedPath, UnifiedDiffs.DEFAULT_CONTEXT_LINES ),
+                    UnifiedDiffs.omitted( UnifiedDiffs.compare( "", created, 0 ), "the content is the one supplied" ),
                     List.of( AffectedResource.of( file, ChangeKind.CREATED ) ),
                     reveal,
                     EditResult.NO_UNDO_STATE,
@@ -1769,7 +1769,7 @@ public class CodeEditingService
             if ( !originalSource.equals( newSource ) )
             {
                 TextEditRequest edit = minimalReplacement( new Document( originalSource ), originalSource, newSource );
-                return applyTextEdits( projectName, filePath, IResource.NULL_STAMP, List.of( edit ), false );
+                return applyTextEdits( projectName, filePath, IResource.NULL_STAMP, List.of( edit ), false, true );
             }
 
             EditSynchronization synchronization = synchronizeAfterEdit( file, 1, currentHistoryState( file ) );
@@ -2210,7 +2210,7 @@ public class CodeEditingService
                     before,
                     ResourceVersion.UNKNOWN,
                     List.of( applied ),
-                    UnifiedDiffs.diff( removed, filePath, "", filePath, UnifiedDiffs.DEFAULT_CONTEXT_LINES ),
+                    UnifiedDiffs.omitted( UnifiedDiffs.compare( removed, "", 0 ), "the removed content is in Local History" ),
                     List.of( AffectedResource.of( file, ChangeKind.DELETED ) ),
                     EditorReveal.none(),
                     undoState != null ? undoState.getModificationTime() : EditResult.NO_UNDO_STATE,
@@ -2970,6 +2970,18 @@ public class CodeEditingService
     public EditResult applyTextEdits( String projectName, String filePath, long expectedModificationStamp,
                                       List<TextEditRequest> requestedEdits, boolean preview )
     {
+        // The caller wrote these edits, so a diff would only echo them back; a preview is
+        // the one case where seeing the outcome is the point, and it keeps the diff.
+        return applyTextEdits( projectName, filePath, expectedModificationStamp, requestedEdits, preview, false );
+    }
+
+    /**
+     * @param showDiff whether an applied result carries the diff - the only account
+     *            of an edit the IDE computed, such as a format or organize imports
+     */
+    private EditResult applyTextEdits( String projectName, String filePath, long expectedModificationStamp,
+                                       List<TextEditRequest> requestedEdits, boolean preview, boolean showDiff )
+    {
         Objects.requireNonNull( projectName );
         Objects.requireNonNull( filePath );
         Objects.requireNonNull( requestedEdits );
@@ -3050,8 +3062,9 @@ public class CodeEditingService
             }
 
             String updated = document.get();
-            String diff = UnifiedDiffs.diff( original, filePath, updated, filePath,
-                    UnifiedDiffs.DEFAULT_CONTEXT_LINES );
+            String diff = showDiff || preview
+                    ? UnifiedDiffs.diff( original, filePath, updated, filePath, UnifiedDiffs.DEFAULT_CONTEXT_LINES )
+                    : UnifiedDiffs.omitted( UnifiedDiffs.compare( original, updated, 0 ), "the change is the one requested" );
 
             List<AppliedEdit> applied = new ArrayList<>();
             for ( int i = 0; i < children.size(); i++ )

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/resources/EditResult.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/resources/EditResult.java
@@ -29,6 +29,12 @@ import com.github.gradusnikov.eclipse.assistai.mcp.results.DiagnosticCode;
  * behind, because a refactoring silently invalidates every {@code modificationStamp}
  * the caller holds. There is deliberately no per-entry diff or edit list: that would
  * put a second unbounded content payload in every refactoring result.
+ * <p>
+ * {@link #unifiedDiff()} is the complete diff when it is the caller's only account of
+ * the change - a preview, or an edit the IDE computed such as a format or organize
+ * imports. When the caller supplied the text itself the diff would only echo it back,
+ * so it is replaced by a single {@code \ diff omitted (+added -removed lines)} line;
+ * an unchanged file gives an empty string either way.
  */
 public record EditResult(
     EditStatus status,

--- a/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/tools/UnifiedDiffs.java
+++ b/plugins/com.github.gradusnikov.eclipse.plugin.assistai.main/src/com/github/gradusnikov/eclipse/assistai/tools/UnifiedDiffs.java
@@ -106,6 +106,20 @@ public final class UnifiedDiffs
         return "--- " + oldLabel + "\n+++ " + newLabel + "\n" + body;
     }
 
+    /**
+     * The line counts of a change in place of its diff, for a result whose caller already
+     * holds the text - repeating it back would only cost tokens. Identical sides give an
+     * empty string, like {@link #diff}.
+     */
+    public static String omitted( Unified unified, String reason )
+    {
+        if ( unified.isEmpty() )
+        {
+            return "";
+        }
+        return "\\ diff omitted (+" + unified.addedLines() + " -" + unified.removedLines() + " lines): " + reason + "\n";
+    }
+
     private static byte[] toBytes( String content )
     {
         return content == null ? new byte[0] : content.getBytes( StandardCharsets.UTF_8 );

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeEditingServicePDETest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/mcp/services/CodeEditingServicePDETest.java
@@ -165,6 +165,8 @@ public class CodeEditingServicePDETest {
         EditResult inserted = insertIntoFile("src/testFile.txt", "Inserted", 2);
         assertEquals(EditResult.EditStatus.APPLIED, inserted.status());
         assertEquals("Line 1\nInserted\nLine 2\n", ResourceUtilities.readFileContent(testFile));
+        // The caller wrote the text, so the result counts the change instead of echoing it.
+        assertEquals("\\ diff omitted (+1 -0 lines): the change is the one requested\n", inserted.unifiedDiff());
 
         // One past the last line appends rather than failing.
         EditResult appended = insertIntoFile("src/testFile.txt", "Appended", 4);
@@ -860,6 +862,22 @@ public class ApplicationNew {
         String formatted = ResourceUtilities.readFileContent(testFile);
         assertTrue(formatted.contains("a = 1;"), formatted);
         assertFalse(formatted.contains("\r"), formatted);
+        // The IDE computed this change, so the diff is the caller's only account of it.
+        assertTrue(result.unifiedDiff().contains("-void f(){a=1;}"), result.unifiedDiff());
+    }
+
+    @Test
+    public void testReplaceFileContent_previewKeepsTheWholeDiff() throws CoreException, IOException {
+        createFile("src/long.txt", "old\n");
+        String longContent = "line\n".repeat(200);
+
+        EditResult result = service.replaceFileContent(TEST_PROJECT_NAME, "src/long.txt", longContent, IResource.NULL_STAMP, true);
+
+        assertEquals(EditResult.EditStatus.PREVIEW, result.status());
+        // A preview exists to show the outcome, so its diff is never cut short; a large reply is the client's to page.
+        String diff = result.unifiedDiff();
+        assertTrue(diff.startsWith("--- src/long.txt\n+++ src/long.txt\n@@"), diff);
+        assertEquals(200, diff.lines().filter("+line"::equals).count(), diff);
     }
 
     private IFile createFile(String path, String content) throws CoreException {

--- a/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/tools/UnifiedDiffsTest.java
+++ b/tests/com.github.gradusnikov.eclipse.plugin.assistai.main.tests/src/com/github/gradusnikov/eclipse/assistai/tools/UnifiedDiffsTest.java
@@ -93,4 +93,20 @@ public class UnifiedDiffsTest
 
         assertFalse( diff.isEmpty(), "a line-ending change is a change" );
     }
+
+    @Test
+    public void omittedIsTheCountsAndTheReason()
+    {
+        UnifiedDiffs.Unified unified = UnifiedDiffs.compare( "a\nb\n", "a\nc\nd\n", 3 );
+
+        assertEquals( "\\ diff omitted (+2 -1 lines): because\n", UnifiedDiffs.omitted( unified, "because" ) );
+    }
+
+    @Test
+    public void omittedIsEmptyForIdenticalSides()
+    {
+        UnifiedDiffs.Unified unified = UnifiedDiffs.compare( "same\n", "same\n", 3 );
+
+        assertEquals( "", UnifiedDiffs.omitted( unified, "because" ) );
+    }
 }


### PR DESCRIPTION
Every edit request provides the same response - a diff of the edit made.

It is consistent but many edit requests actually carry the diff as input! Then, the diff response just echoes back the request, which is simply a huge waste of context and tokens.

At least my Claude Code is unable to drop a response from context no matter how useless it is.

This PR: The following edit requests don't echo the diff back, and instead just provide a quick summary that the edit was applied.
* applyTextEdits
* replaceString
* insertIntoFile
* deleteLinesInFile
* replaceFileContent
* applyPatch
* normalizeLineDelimiters (this one technically does not echo the input but just returns all lines of a file twice...)
* createFile
* deleteFile

Edits where the diff wasn't an input are returned as before:
* formatFile
* organizeImports
* organizeImportsInPackage
* undoEdit
* formatCode

Also any edit with the preview flag behaves as before, since the diff seems to be the point of a preview.